### PR TITLE
Allow AZ aliases

### DIFF
--- a/collections/ansible_collections/purestorage/fusion/plugins/modules/fusion_array.py
+++ b/collections/ansible_collections/purestorage/fusion/plugins/modules/fusion_array.py
@@ -41,7 +41,8 @@ options:
     - The human name of the array.
     - If not provided, defaults to `name`
     type: str
-  az:
+  availability_zone:
+    aliases: [ az ]
     description:
     - The availability zone the array is located in.
     type: str
@@ -190,7 +191,7 @@ def main():
     argument_spec.update(
         dict(
             name=dict(type="str", required=True),
-            az=dict(type="str", required=True),
+            availability_zone=dict(type="str", required=True, aliases=["az"]),
             display_name=dict(type="str"),
             appliance_id=dict(type="str", required=True),
             host_name=dict(type="str", required=True),

--- a/collections/ansible_collections/purestorage/fusion/plugins/modules/fusion_pg.py
+++ b/collections/ansible_collections/purestorage/fusion/plugins/modules/fusion_pg.py
@@ -51,6 +51,7 @@ options:
     type: str
     required: true
   availability_zone:
+    aliases: [ az ]
     description:
     - The name of the availability zone to create the placement group in.
     type: str
@@ -208,7 +209,7 @@ def main():
             display_name=dict(type="str"),
             tenant=dict(type="str", required=True),
             tenant_space=dict(type="str", required=True),
-            availability_zone=dict(type="str"),
+            availability_zone=dict(type="str", aliases=["az"]),
             state=dict(type="str", default="present", choices=["absent", "present"]),
             placement_engine=dict(
                 type="str", default="heuristics", choices=["heuristics", "pure1meta"]

--- a/collections/ansible_collections/purestorage/fusion/plugins/modules/fusion_tn.py
+++ b/collections/ansible_collections/purestorage/fusion/plugins/modules/fusion_tn.py
@@ -42,6 +42,7 @@ options:
     default: present
     choices: [ absent, present ]
   availability_zone:
+    aliases: [ az ]
     description:
     - The name of the availability zone for the tenant network.
     type: str
@@ -243,7 +244,7 @@ def main():
         dict(
             name=dict(type="str", required=True),
             display_name=dict(type="str"),
-            availability_zone=dict(type="str", required=True),
+            availability_zone=dict(type="str", required=True, aliases=["az"]),
             prefix=dict(type="str"),
             gateway=dict(type="str"),
             mtu=dict(type="int", default=1500),


### PR DESCRIPTION
##### SUMMARY
Ensure `az` can always be used as an alias for `availability_zone` in parameters

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
fusion_array.py
fusion_pg.py
fusion_tn.py