### PR TITLE
Fix get_fusion to allow for env variables

### DIFF
--- a/changelogs/fragments/29_use_env.yaml
+++ b/changelogs/fragments/29_use_env.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - Allow correct use of environmental variables for App ID and private file file

--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -28,14 +28,12 @@ options:
       - Path to the private key file
       - Defaults to the set environment variable under FUSION_PRIVATE_KEY_FILE.
     type: str
-    required: true
   app_id:
     description:
       - Application ID from Pure1 Registration page
       - eg. pure1:apikey:dssf2331sd
       - Defaults to the set environment variable under FUSION_APP_ID
     type: str
-    required: true
 notes:
   - This module requires the I(purefusion) Python library
   - You must set C(FUSION_APP_ID) and C(FUSION_PRIVATE_KEY_FILE) environment variables

--- a/plugins/module_utils/fusion.py
+++ b/plugins/module_utils/fusion.py
@@ -93,6 +93,6 @@ def fusion_argument_spec():
     """Return standard base dictionary used for the argument_spec argument in AnsibleModule"""
 
     return dict(
-        app_id=dict(no_log=True, required=True),
-        key_file=dict(no_log=False, required=True),
+        app_id=dict(no_log=True),
+        key_file=dict(no_log=False),
     )


### PR DESCRIPTION
##### SUMMARY
Remove `required` for `app_id` and `key_file` so that environmental variables can be used to set these.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fusion.py