### PR TITLE
Add missing region parameter for PG and TN modules

### DIFF
--- a/changelogs/fragments/44_fix_missing_regions.yaml
+++ b/changelogs/fragments/44_fix_missing_regions.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+ - fusion_pg - Add missing 'region' parameter
+ - fusion_tn - Add missing 'region' parameter

--- a/plugins/modules/fusion_pg.py
+++ b/plugins/modules/fusion_pg.py
@@ -46,6 +46,11 @@ options:
     - The name of the tenant space.
     type: str
     required: true
+  region:
+    description:
+    - The name of the region the availability zone is in.
+    type: str
+    required: true
   availability_zone:
     aliases: [ az ]
     description:
@@ -117,7 +122,8 @@ def get_az(module, fusion):
     api_instance = purefusion.AvailabilityZonesApi(fusion)
     try:
         return api_instance.get_availability_zone(
-            availability_zone_name=module.params["availability_zone"]
+            availability_zone_name=module.params["availability_zone"],
+            region_name=module.params["region"],
         )
     except purefusion.rest.ApiException:
         return None
@@ -205,6 +211,7 @@ def main():
             display_name=dict(type="str"),
             tenant=dict(type="str", required=True),
             tenant_space=dict(type="str", required=True),
+            region=dict(type="str", required=True),
             availability_zone=dict(type="str", aliases=["az"]),
             state=dict(type="str", default="present", choices=["absent", "present"]),
             placement_engine=dict(

--- a/plugins/modules/fusion_tn.py
+++ b/plugins/modules/fusion_tn.py
@@ -37,6 +37,11 @@ options:
     type: str
     default: present
     choices: [ absent, present ]
+  region:
+    description:
+    - The name of the region the availability zone is in
+    type: str
+    required: true
   availability_zone:
     aliases: [ az ]
     description:
@@ -142,6 +147,7 @@ def get_az(module, fusion):
     try:
         return az_api_instance.get_availability_zone(
             availability_zone_name=module.params["availability_zone"],
+            region_name=module.params["region"],
         )
     except purefusion.rest.ApiException:
         return None
@@ -239,6 +245,7 @@ def main():
     argument_spec.update(
         dict(
             name=dict(type="str", required=True),
+            region=dict(type="str", required=True),
             display_name=dict(type="str"),
             availability_zone=dict(type="str", required=True, aliases=["az"]),
             prefix=dict(type="str"),


### PR DESCRIPTION
##### SUMMARY
Adding parameter 'region' to two modules that were missing it. Required parameter to ensure AZ chacks are done in the correct region.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fusion_pg.py
fusion_tn.py