### PR TITLE
Rename Tenant Networks to Storage Endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Purestorage.Fusion Release Notes
 
 .. contents:: Topics
 
+unreleased
+======
+
+Bugfixes
+--------
+
+- rename fusion_tn to fusion_se (Tenant networks to Storage endpoints)
 
 v1.3.0
 ======

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The Pure Storage Fusion collection consists of the latest versions of the Fusion
 - fusion_ra: Manage role assignments in Pure Storage Fusion
 - fusion_region: Manage regions in Pure Storage Fusion
 - fusion_sc: Manage storage classes in Pure Storage Fusion
+- fusion_se: Manage storage endpoints in Pure Storage Fusion
 - fusion_ss: Manage storage services in Pure Storage Fusion
 - fusion_tenant: Manage tenants in Pure Storage Fusion
-- fusion_tn: Manage tenant networks in Pure Storage Fusion
 - fusion_ts: Manage tenant spaces in Pure Storage Fusion
 - fusion_volume: Manage volumes in Pure Storage Fusion
 

--- a/plugins/modules/fusion_az.py
+++ b/plugins/modules/fusion_az.py
@@ -81,8 +81,8 @@ def get_az(module, fusion):
     az_api_instance = purefusion.AvailabilityZonesApi(fusion)
     try:
         return az_api_instance.get_availability_zone(
-            availability_zone_name=module.params["name"],
             region_name=module.params["region"],
+            availability_zone_name=module.params["name"],
         )
     except purefusion.rest.ApiException:
         return None

--- a/plugins/modules/fusion_region.py
+++ b/plugins/modules/fusion_region.py
@@ -84,7 +84,7 @@ def get_region(module, fusion):
     region_api_instance = purefusion.RegionsApi(fusion)
     try:
         return region_api_instance.get_region(
-            region_name=module.params["region"],
+            region_name=module.params["name"],
         )
     except purefusion.rest.ApiException:
         return None
@@ -125,7 +125,7 @@ def delete_region(module, fusion):
     changed = True
     if not module.check_mode:
         try:
-            reg_api_instance.delete_region(region_name=module.params["region"])
+            reg_api_instance.delete_region(region_name=module.params["name"])
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Region {0} creation failed.: {1}".format(

--- a/plugins/modules/fusion_se.py
+++ b/plugins/modules/fusion_se.py
@@ -10,30 +10,29 @@ __metaclass__ = type
 
 DOCUMENTATION = r"""
 ---
-module: fusion_tn
+module: fusion_se
 version_added: '1.0.0'
-short_description:  Manage tenant networks in Pure Storage Fusion
+short_description:  Manage storage endpoints in Pure Storage Fusion
 description:
-- Create or delete tenant networks in Pure Storage Fusion.
+- Create or delete storage endpoints in Pure Storage Fusion.
 notes:
 - Supports C(check_mode).
-- Currently this only supports a single tenant subnet per tenant network.
 author:
 - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:
-    - The name of the tenant network.
+    - The name of the storage endpoint.
     type: str
     required: true
   display_name:
     description:
-    - The human name of the tenant network.
+    - The human name of the storage endpoint.
     - If not provided, defaults to I(name).
     type: str
   state:
     description:
-    - Define whether the tenant network should exist or not.
+    - Define whether the storage endpoint should exist or not.
     type: str
     default: present
     choices: [ absent, present ]
@@ -45,17 +44,23 @@ options:
   availability_zone:
     aliases: [ az ]
     description:
-    - The name of the availability zone for the tenant network.
+    - The name of the availability zone for the storage endpoint.
     type: str
     required: true
-  provider_subnets:
+  endpoint_type:
     description:
-    - List of provider subnets to assign to the tenant networks subnet.
+    - Type of the storage endpoint. Only iSCSI is available at the moment.
+    type: str
+    default: iscsi
+    choices: [ iscsi ]
+  network_interface_groups:
+    description:
+    - List of network interface groups to assign to the storage endpoints.
     type: list
     elements: str
   addresses:
     description:
-    - List of IP addresses to be used in the subnet of the tenant network.
+    - List of IP addresses to be used in the subnet of the storage endpoint.
     - IP addresses must include a CIDR notation.
     - IPv4 and IPv6 are fully supported.
     type: list
@@ -65,40 +70,31 @@ options:
     - Address of the subnet gateway.
     - Currently this must be provided.
     type: str
-  mtu:
-    description:
-    - MTU setting for the subnet.
-    default: 1500
-    type: int
-  prefix:
-    description:
-    - Network prefix in CIDR format.
-    - This will be deprecated soon.
-    type: str
 extends_documentation_fragment:
 - purestorage.fusion.purestorage.fusion
 """
 
 EXAMPLES = r"""
-- name: Create new tenant network foo in AZ bar
-  purestorage.fusion.fusion_tn:
+- name: Create new storage endpoint foo in AZ bar
+  purestorage.fusion.fusion_se:
     name: foo
     availability_zone: bar
-    mtu: 9000
     gateway: 10.21.200.1
+    region: us-west
     addresses:
       - 10.21.200.124/24
       - 10.21.200.36/24
-    provider_subnets:
+    network_interface_groups:
       - subnet-0
     state: present
     app_id: key_name
     key_file: "az-admin-private-key.pem"
 
-- name: Delete tenant network foo in AZ bar
-  purestorage.fusion.fusion_tn:
+- name: Delete storage endpoint foo in AZ bar
+  purestorage.fusion.fusion_se:
     name: foo
     availability_zone: bar
+    region: us-west
     state: absent
     app_id: key_name
     key_file: "az-admin-private-key.pem"
@@ -126,21 +122,6 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
-
-def get_ps(module, fusion):
-    """Check all Provider Subnets"""
-    ps_api_instance = purefusion.ProviderSubnetsApi(fusion)
-    for subnet in range(0, len(module.params["provider_subnets"])):
-        try:
-            ps_api_instance.get_provider_subnet(
-                availability_zone_name=module.params["availability_zone"],
-                provider_subnet=module.params["provider_subnets"][subnet],
-            )
-        except purefusion.rest.ApiException:
-            return False
-    return True
-
-
 def get_az(module, fusion):
     """Availability Zone or None"""
     az_api_instance = purefusion.AvailabilityZonesApi(fusion)
@@ -153,28 +134,25 @@ def get_az(module, fusion):
         return None
 
 
-def get_tn(module, fusion):
-    """Tenant Network or None"""
-    api_instance = purefusion.TenantNetworksApi(fusion)
+def get_se(module, fusion):
+    """Storage Endpoint or None"""
+    se_api_instance = purefusion.StorageEndpointsApi(fusion)
     try:
-        return api_instance.get_tenant_network(
-            tenant_network=module.params["name"],
+        return se_api_instance.get_storage_endpoint(
+            region_name=module.params["region"],
+            storage_endpoint_name=module.params["name"],
             availability_zone_name=module.params["availability_zone"],
         )
     except purefusion.rest.ApiException:
         return None
 
 
-def create_tn(module, fusion):
-    """Create Tenant Network"""
+def create_se(module, fusion):
+    """Create Storage Endpoint"""
 
-    tn_api_instance = purefusion.TenantNetworksApi(fusion)
+    se_api_instance = purefusion.StorageEndpointsApi(fusion)
 
     changed = True
-    if module.params["gateway"] and module.params["gateway"] not in IPNetwork(
-        module.params["prefix"]
-    ):
-        module.fail_json(msg="Gateway and subnet prefix are not compatible.")
 
     if not module.check_mode:
         if not module.params["display_name"]:
@@ -182,33 +160,36 @@ def create_tn(module, fusion):
         else:
             display_name = module.params["display_name"]
         try:
-            if module.params["gateway"]:
-                tsubnet = purefusion.TenantSubnetPost(
-                    prefix=module.params["prefix"],
-                    addresses=module.params["addresses"],
-                    gateway=module.params["gateway"],
-                    mtu=module.params["mtu"],
-                    provider_subnets=module.params["provider_subnets"],
-                )
-            else:
-                tsubnet = purefusion.TenantSubnetPost(
-                    prefix=module.params["prefix"],
-                    addresses=module.params["addresses"],
-                    mtu=module.params["mtu"],
-                    provider_subnets=module.params["provider_subnets"],
-                )
-            tnet = purefusion.TenantNetworkPost(
-                tenant_subnets=[tsubnet],
+            ifaces = []
+            for address in module.params["addresses"]:
+                if module.params["gateway"]:
+                    iface = purefusion.StorageEndpointIscsiDiscoveryInterfacePost(
+                        address=address,
+                        gateway=module.params["gateway"],
+                        network_interface_groups=module.params["network_interface_groups"],
+                    )
+                else:
+                    iface = purefusion.StorageEndpointIscsiDiscoveryInterfacePost(
+                        address=address,
+                        network_interface_groups=module.params["network_interface_groups"],
+                    )
+                ifaces.append(iface)
+            sendp = purefusion.StorageEndpointPost(
+                endpoint_type=module.params["endpoint_type"],
+                iscsi=purefusion.StorageEndpointIscsiPost(
+                        discovery_interfaces=ifaces,
+                    ),
                 name=module.params["name"],
                 display_name=display_name,
             )
-            tn_api_instance.create_tenant_network(
-                tnet,
+            se_api_instance.create_storage_endpoint(
+                sendp,
+                region_name=module.params["region"],
                 availability_zone_name=module.params["availability_zone"],
             )
         except purefusion.rest.ApiException as err:
             module.fail_json(
-                msg="Tenant Network {0} creation failed.: {1}".format(
+                msg="Storage Endpoint {0} creation failed.: {1}".format(
                     module.params["name"], err
                 )
             )
@@ -216,25 +197,26 @@ def create_tn(module, fusion):
     module.exit_json(changed=changed)
 
 
-def delete_tn(module, fusion):
-    """Delete Tenant Network"""
+def delete_se(module, fusion):
+    """Delete Storage Endpoint"""
     changed = True
-    tn_api_instance = purefusion.TenantNetworksApi(fusion)
+    se_api_instance = purefusion.StorageEndpointsApi(fusion)
     if not module.check_mode:
         try:
-            tn_api_instance.delete_tenant_network(
+            se_api_instance.delete_storage_endpoint(
+                region_name=module.params["region"],
                 availability_zone_name=module.params["availability_zone"],
-                tenant_network=module.params["name"],
+                storage_endpoint_name=module.params["name"],
             )
         except purefusion.rest.ApiException:
             module.fail_json(
-                msg="Delete Tenant Network {0} failed.".format(module.params["name"])
+                msg="Delete Storage Endpoint {0} failed.".format(module.params["name"])
             )
     module.exit_json(changed=changed)
 
 
-def update_tn(module, fusion, tenant_network):
-    """Update Tenant Network"""
+def update_se(module, fusion, storage_endpoint):
+    """Update Storage Endpoint"""
     changed = False
     module.exit_json(changed=changed)
 
@@ -245,14 +227,13 @@ def main():
     argument_spec.update(
         dict(
             name=dict(type="str", required=True),
-            region=dict(type="str", required=True),
             display_name=dict(type="str"),
+            region=dict(type="str", required=True),
             availability_zone=dict(type="str", required=True, aliases=["az"]),
-            prefix=dict(type="str"),
-            gateway=dict(type="str"),
-            mtu=dict(type="int", default=1500),
-            provider_subnets=dict(type="list", elements="str"),
+            endpoint_type=dict(type="str", default="iscsi", choices=["iscsi"]),
             addresses=dict(type="list", elements="str"),
+            gateway=dict(type="str"),
+            network_interface_groups=dict(type="list", elements="str"),
             state=dict(type="str", default="present", choices=["absent", "present"]),
         )
     )
@@ -266,10 +247,6 @@ def main():
     fusion = get_fusion(module)
     if not get_az(module, fusion):
         module.fail_json(msg="Availability Zone {0} does not exist")
-    if module.params["provider_subnets"] and not get_ps(module, fusion):
-        module.fail_json(
-            msg="Not all of the provider subnets exist in the specified AZ"
-        )
     for address in range(0, len(module.params["addresses"])):
         if "/" not in module.params["addresses"][address]:
             module.fail_json(msg="All addresses must include a CIDR notation")
@@ -280,25 +257,24 @@ def main():
                 )
             )
 
-    tnet = get_tn(module, fusion)
+    sendp = get_se(module, fusion)
 
-    if state == "present" and not tnet:
+    if state == "present" and not sendp:
         if not (
             module.params["addresses"]
             and module.params["gateway"]  # Soon to be optional
-            and module.params["prefix"]  # To be removed soon
-            and module.params["provider_subnets"]
+            and module.params["network_interface_groups"]
         ):
             module.fail_json(
-                msg="When creating a new tenant network, the following "
-                "parameters must be supplied: `gateway`, `addresses`, `prefix` "
-                "and `provider_subnets`"
+                msg="When creating a new storage endpoint, the following "
+                "parameters must be supplied: `gateway`, `addresses` "
+                "and `network_interface_groups`"
             )
-        create_tn(module, fusion)
-    elif state == "present" and tnet:
-        update_tn(module, fusion, tnet)
-    elif state == "absent" and tnet:
-        delete_tn(module, fusion)
+        create_se(module, fusion)
+    elif state == "present" and sendp:
+        update_se(module, fusion, sendp)
+    elif state == "absent" and sendp:
+        delete_se(module, fusion)
 
     module.exit_json(changed=False)
 


### PR DESCRIPTION
##### SUMMARY
This commit propagates changes in underlying Python SDK,
where Tenant Networks were renamed to Storage Endpoints.

Fixes internal issue HM-4757.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fusion_tn.py -> fusion_se.py (+ code changes in said file)
