### PR TITLE
Add region as required parameter

### DIFF
--- a/plugins/modules/fusion_pg.py
+++ b/plugins/modules/fusion_pg.py
@@ -74,6 +74,7 @@ EXAMPLES = r"""
     tenant: test
     tenant_space: space_1
     availability_zone: az1
+    region: region1
     placement_engine: pure1meta
     state: present
     app_id: key_name
@@ -84,6 +85,7 @@ EXAMPLES = r"""
     name: foo
     tenant: test
     tenant_space: space_1
+    region: region1
     state: absent
     app_id: key_name
     key_file: "az-admin-private-key.pem"


### PR DESCRIPTION
##### SUMMARY
This PR fixes fusion_pg docs examples.
It adds region as required parameter in examples section.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
fusion_pg

##### ADDITIONAL INFORMATION
Check docs by using:
```ANSIBLE_LIBRARY=./plugins/modules ansible-doc fusion_pg```