### PR TITLE
Fix typo in fusion_ts docs

### DIFF
--- a/plugins/modules/fusion_ts.py
+++ b/plugins/modules/fusion_ts.py
@@ -46,7 +46,7 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = r"""
-- name: Create new teanat space foo for tenany bar
+- name: Create new tenant space foo for tenant bar
   purestorage.fusion.fusion_ts:
     name: foo
     tenant: bar


### PR DESCRIPTION
##### SUMMARY
Fix typo in fusion_ts docs. Fix "tenant" word 
https://github.com/Pure-Storage-Ansible/Fusion-Collection/blob/9f38a3675c15376c49c4d610fcce3fb1e40d2167/plugins/modules/fusion_ts.py#L49

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
fusion_ts

