### PR TITLE
Change regex for ISCSI IQN pattern

### DIFF
--- a/plugins/modules/fusion_hap.py
+++ b/plugins/modules/fusion_hap.py
@@ -243,7 +243,7 @@ def main():
     module.params["name"] = module.params["name"].lower()
     hap_pattern = re.compile("^[a-zA-Z0-9]([a-zA-Z0-9-_]{0,61}[a-zA-Z0-9])?$")
     iqn_pattern = re.compile(
-        r"^iqn\.\d{4}-\d{2}((?<!-)\.(?!-)[a-zA-Z0-9\-]+){1,63}(?<!-)(?<!\.)(:[^:]+)?$"
+        r"^iqn\.\d{4}-\d{2}((?<!-)\.(?!-)[a-zA-Z0-9\-]+){1,63}(?<!-)(?<!\.)(:(?!:)[^,\s'\"]+)?$"
     )
     if not hap_pattern.match(module.params["name"]):
         module.fail_json(


### PR DESCRIPTION
##### SUMMARY
Allowed `:` symbol in IQN pattern because some IQN cases do not match the pattern. For example: `iqn.2052-02.foo.org:01:c5f446d388f4`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fusion_hap

##### ADDITIONAL INFORMATION
Now IQN pattern restricts using `:` prefix in unique name. Also it restricts using `' " \s ,` symbols
This pattern refers to RFC [documentation](https://www.rfc-editor.org/rfc/rfc3720#section-3.2.6.3.1) 