### PR TITLE
Fix host access policy deletion

### DIFF
--- a/changelogs/fragments/PR55_host_access_policy.yaml
+++ b/changelogs/fragments/PR55_host_access_policy.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - fusion_hap - could not delete host access policy without iqn option. Now it needs only name option for deletion
+    (https://github.com/Pure-Storage-Ansible/Fusion-Collection/pull/55)
+  - fusion_hap - uppercase names were not supported. Now uppercase names are allowed
+    (https://github.com/Pure-Storage-Ansible/Fusion-Collection/pull/55)

--- a/plugins/modules/fusion_hap.py
+++ b/plugins/modules/fusion_hap.py
@@ -240,25 +240,29 @@ def main():
     )
 
     fusion = get_fusion(module)
-    module.params["name"] = module.params["name"].lower()
+
     hap_pattern = re.compile("^[a-zA-Z0-9]([a-zA-Z0-9-_]{0,61}[a-zA-Z0-9])?$")
     iqn_pattern = re.compile(
         r"^iqn\.\d{4}-\d{2}((?<!-)\.(?!-)[a-zA-Z0-9\-]+){1,63}(?<!-)(?<!\.)(:(?!:)[^,\s'\"]+)?$"
     )
+
     if not hap_pattern.match(module.params["name"]):
         module.fail_json(
             msg="Host Access Policy {0} does not conform to naming convention".format(
                 module.params["name"]
             )
         )
-    if not iqn_pattern.match(module.params["iqn"]):
-        module.fail_json(
-            msg="IQN {0} is not a valid iSCSI IQN".format(module.params["name"])
-        )
+
     state = module.params["state"]
     host = get_host(module, fusion)
     _check_iqn(module, fusion)
+
     if not host and state == "present":
+        if not iqn_pattern.match(module.params["iqn"]):
+            module.fail_json(
+                msg="IQN {0} is not a valid iSCSI IQN".format(module.params["name"])
+            )
+
         create_hap(module, fusion)
     elif host and state == "absent":
         delete_hap(module, fusion)


### PR DESCRIPTION
##### SUMMARY

Pr fixes IQN requirement for host access policy deletion. Now only host access policy is needed.
Also bug with uppercase names was fixed.

##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
fusion_hap

##### ADDITIONAL INFORMATION
Module always checked IQN parameter even in deletion operation. 
Also you could not create name with uppercase letters. 
