### PR TITLE
Await all currently called asynchronous API calls

### DIFF
--- a/plugins/module_utils/operations.py
+++ b/plugins/module_utils/operations.py
@@ -19,7 +19,7 @@ except ImportError:
 def await_operation(module, fusion, op_id, fail_playbook_if_operation_fails=True):
     """
     Waits for given operation to finish.
-    Throws an exception if the operation fails or times out.
+    Throws an exception by default if the operation fails.
     """
     op_api = purefusion.OperationsApi(fusion)
     next_timeout = 250

--- a/plugins/modules/fusion_az.py
+++ b/plugins/modules/fusion_az.py
@@ -75,6 +75,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def get_az(module, fusion):
     """Get Availability Zone or None"""
@@ -107,10 +111,11 @@ def delete_az(module, fusion):
     changed = True
     if not module.check_mode:
         try:
-            az_api_instance.delete_availability_zone(
+            op = az_api_instance.delete_availability_zone(
                 region_name=module.params["region"],
                 availability_zone_name=module.params["name"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Availability Zone {0} deletion failed.: {1}".format(
@@ -137,9 +142,10 @@ def create_az(module, fusion):
                 name=module.params["name"],
                 display_name=display_name,
             )
-            az_api_instance.create_availability_zone(
+            op = az_api_instance.create_availability_zone(
                 azone, region_name=module.params["region"]
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Availability Zone {0} creation failed.: {1}".format(

--- a/plugins/modules/fusion_hap.py
+++ b/plugins/modules/fusion_hap.py
@@ -126,6 +126,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def _check_iqn(module, fusion):
     hap_api_instance = purefusion.HostAccessPoliciesApi(fusion)
@@ -160,7 +164,7 @@ def create_hap(module, fusion):
     changed = True
     if not module.check_mode:
         try:
-            hap_api_instance.create_host_access_policy(
+            op = hap_api_instance.create_host_access_policy(
                 purefusion.HostAccessPoliciesPost(
                     iqn=module.params["iqn"],
                     personality=module.params["personality"],
@@ -168,6 +172,7 @@ def create_hap(module, fusion):
                     display_name=module.params["display_name"],
                 )
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Host Access Policy {0} creation failed: {1}".format(
@@ -183,9 +188,10 @@ def delete_hap(module, fusion):
     changed = True
     if not module.check_mode:
         try:
-            hap_api_instance.delete_host_access_policy(
+            op = hap_api_instance.delete_host_access_policy(
                 host_access_policy_name=module.params["name"]
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Host Access Policy {0} deletion failed: {1}".format(

--- a/plugins/modules/fusion_nig.py
+++ b/plugins/modules/fusion_nig.py
@@ -117,6 +117,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def get_nig(module, fusion):
     """Check Network Interface Group"""
@@ -178,11 +182,12 @@ def create_nig(module, fusion):
                     name=module.params["name"],
                     display_name=display_name,
                 )
-            nig_api_instance.create_network_interface_group(
+            op = nig_api_instance.create_network_interface_group(
                 nig,
                 availability_zone_name=module.params["availability_zone"],
                 region_name=module.params["region"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Network Interface Group {0} creation failed.: {1}".format(
@@ -199,11 +204,12 @@ def delete_nig(module, fusion):
     nig_api_instance = purefusion.NetworkInterfaceGroupsApi(fusion)
     if not module.check_mode:
         try:
-            nig_api_instance.delete_network_interface_group(
+            op = nig_api_instance.delete_network_interface_group(
                 availability_zone_name=module.params["availability_zone"],
                 region_name=module.params["region"],
                 network_interface_group_name=module.params["name"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException:
             module.fail_json(
                 msg="Delete Network Interface Group {0} failed.".format(

--- a/plugins/modules/fusion_pg.py
+++ b/plugins/modules/fusion_pg.py
@@ -111,6 +111,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def get_ts(module, fusion):
     """Tenant Space or None"""
@@ -177,11 +181,12 @@ def create_pg(module, fusion):
                 region=module.params["region"],
                 storage_service=module.params["storage_service"],
             )
-            pg_api_instance.create_placement_group(
+            op = pg_api_instance.create_placement_group(
                 group,
                 tenant_name=module.params["tenant"],
                 tenant_space_name=module.params["tenant_space"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Placement Group {0} creation failed.: {1}".format(
@@ -198,11 +203,12 @@ def delete_pg(module, fusion):
     pg_api_instance = purefusion.PlacementGroupsApi(fusion)
     if not module.check_mode:
         try:
-            pg_api_instance.delete_placement_group(
+            op = pg_api_instance.delete_placement_group(
                 placement_group_name=module.params["name"],
                 tenant_name=module.params["tenant"],
                 tenant_space_name=module.params["tenant_space"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException:
             module.fail_json(
                 msg="Delete Placement Group {0} failed.".format(module.params["name"])

--- a/plugins/modules/fusion_pp.py
+++ b/plugins/modules/fusion_pp.py
@@ -89,8 +89,13 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     get_fusion,
     fusion_argument_spec,
 )
+
 from ansible_collections.purestorage.fusion.plugins.module_utils.parsing import (
     parse_minutes,
+)
+
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
 )
 
 
@@ -121,7 +126,7 @@ def create_pp(module, fusion):
         else:
             display_name = module.params["display_name"]
         try:
-            pp_api_instance.create_protection_policy(
+            op = pp_api_instance.create_protection_policy(
                 purefusion.ProtectionPolicyPost(
                     name=module.params["name"],
                     display_name=display_name,
@@ -137,6 +142,7 @@ def create_pp(module, fusion):
                     ],
                 )
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Protection Policy {0} creation failed.: {1}".format(
@@ -153,9 +159,10 @@ def delete_pp(module, fusion):
     changed = True
     if not module.check_mode:
         try:
-            pp_api_instance.delete_protection_policy(
+            op = pp_api_instance.delete_protection_policy(
                 protection_policy_name=module.params["name"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Protection Policy {0} deletion failed.: {1}".format(

--- a/plugins/modules/fusion_ra.py
+++ b/plugins/modules/fusion_ra.py
@@ -92,6 +92,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def human_to_principal(fusion, user_id):
     """Given a human readable Fusion user, such as a Pure 1 App ID
@@ -183,9 +187,10 @@ def create_ra(module, fusion):
         principal = human_to_principal(fusion, module.params["user"])
         assignment = purefusion.RoleAssignmentPost(scope=scope, principal=principal)
         try:
-            ra_api_instance.create_role_assignment(
+            op = ra_api_instance.create_role_assignment(
                 assignment, role_name=module.params["name"]
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException:
             module.fail_json(
                 msg="{0} level Role Assignment creation for user {1} failed".format(
@@ -202,9 +207,10 @@ def delete_ra(module, fusion):
     if not module.check_mode:
         ra_name = get_ra(module, fusion).name
         try:
-            ra_api_instance.delete_role_assignment(
+            op = ra_api_instance.delete_role_assignment(
                 role_name=module.params["name"], role_assignment_name=ra_name
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException:
             module.fail_json(
                 msg="{0} level Role Assignment delete for user {1} failed".format(

--- a/plugins/modules/fusion_region.py
+++ b/plugins/modules/fusion_region.py
@@ -78,6 +78,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def get_region(module, fusion):
     """Get Region or None"""
@@ -106,7 +110,8 @@ def create_region(module, fusion):
                 name=module.params["name"],
                 display_name=display_name,
             )
-            reg_api_instance.create_region(region)
+            op = reg_api_instance.create_region(region)
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Region {0} creation failed.: {1}".format(
@@ -125,7 +130,8 @@ def delete_region(module, fusion):
     changed = True
     if not module.check_mode:
         try:
-            reg_api_instance.delete_region(region_name=module.params["name"])
+            op = reg_api_instance.delete_region(region_name=module.params["name"])
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Region {0} creation failed.: {1}".format(
@@ -151,10 +157,11 @@ def update_region(module, fusion, region):
                 display_name=purefusion.NullableString(module.params["display_name"])
             )
             try:
-                reg_api_instance.update_region(
+                op = reg_api_instance.update_region(
                     reg,
                     region_name=module.params["name"],
                 )
+                await_operation(module, fusion, op)
             except purefusion.rest.ApiException as err:
                 module.fail_json(
                     msg="Changing region display_name failed: {0}".format(err)

--- a/plugins/modules/fusion_se.py
+++ b/plugins/modules/fusion_se.py
@@ -122,6 +122,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def get_nifg(module, fusion):
     """Check all Network Interface Groups"""
@@ -202,11 +206,12 @@ def create_se(module, fusion):
                 name=module.params["name"],
                 display_name=display_name,
             )
-            se_api_instance.create_storage_endpoint(
+            op = se_api_instance.create_storage_endpoint(
                 sendp,
                 region_name=module.params["region"],
                 availability_zone_name=module.params["availability_zone"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Storage Endpoint {0} creation failed.: {1}".format(
@@ -223,11 +228,12 @@ def delete_se(module, fusion):
     se_api_instance = purefusion.StorageEndpointsApi(fusion)
     if not module.check_mode:
         try:
-            se_api_instance.delete_storage_endpoint(
+            op = se_api_instance.delete_storage_endpoint(
                 region_name=module.params["region"],
                 availability_zone_name=module.params["availability_zone"],
                 storage_endpoint_name=module.params["name"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException:
             module.fail_json(
                 msg="Delete Storage Endpoint {0} failed.".format(module.params["name"])

--- a/plugins/modules/fusion_ss.py
+++ b/plugins/modules/fusion_ss.py
@@ -90,6 +90,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def get_ss(module, fusion):
     """Return Storage Service or None"""
@@ -119,7 +123,8 @@ def create_ss(module, fusion):
                 display_name=display_name,
                 hardware_types=module.params["hardware_types"],
             )
-            ss_api_instance.create_storage_service(s_service)
+            op = ss_api_instance.create_storage_service(s_service)
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Storage Service {0} creation failed.: {1}".format(
@@ -138,9 +143,10 @@ def delete_ss(module, fusion):
     changed = True
     if not module.check_mode:
         try:
-            ss_api_instance.delete_storage_service(
+            op = ss_api_instance.delete_storage_service(
                 storage_service_name=module.params["name"]
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Storage Service {0} deletion failed.: {1}".format(
@@ -175,10 +181,11 @@ def update_ss(module, fusion):
             display_name=purefusion.NullableString(display_name),
         )
         try:
-            ss_api_instance.update_storage_service(
+            op = ss_api_instance.update_storage_service(
                 sservice,
                 storage_service_name=module.params["name"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Changing storage service {0} failed. Error: {1}".format(

--- a/plugins/modules/fusion_tenant.py
+++ b/plugins/modules/fusion_tenant.py
@@ -71,6 +71,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def get_tenant(module, fusion):
     """Return Tenant or None"""
@@ -96,7 +100,8 @@ def create_tenant(module, fusion):
                 name=module.params["name"],
                 display_name=display_name,
             )
-            api_instance.create_tenant(tenant)
+            op = api_instance.create_tenant(tenant)
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Tenant {0} creation failed.: {1}".format(
@@ -125,10 +130,11 @@ def update_tenant(module, fusion):
                 display_name=purefusion.NullableString(module.params["display_name"]),
             )
             try:
-                api_instance.update_tenant(
+                op = api_instance.update_tenant(
                     new_tenant,
                     tenant_name=module.params["name"],
                 )
+                await_operation(module, fusion, op)
             except purefusion.rest.ApiException as err:
                 module.fail_json(
                     msg="Changing tenant display_name failed: {0}".format(err)
@@ -143,7 +149,8 @@ def delete_tenant(module, fusion):
     api_instance = purefusion.TenantsApi(fusion)
     if not module.check_mode:
         try:
-            api_instance.delete_tenant(tenant_name=module.params["name"])
+            op = api_instance.delete_tenant(tenant_name=module.params["name"])
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Deleting Tenant {0} failed: {1}".format(module.params["name"], err)

--- a/plugins/modules/fusion_ts.py
+++ b/plugins/modules/fusion_ts.py
@@ -78,6 +78,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
+    await_operation,
+)
+
 
 def get_ts(module, fusion):
     """Tenant Space or None"""
@@ -116,10 +120,11 @@ def create_ts(module, fusion):
                 name=module.params["name"],
                 display_name=display_name,
             )
-            ts_api_instance.create_tenant_space(
+            op = ts_api_instance.create_tenant_space(
                 tspace,
                 tenant_name=module.params["tenant"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException as err:
             module.fail_json(
                 msg="Tenant Space {0} creation failed.: {1}".format(
@@ -136,10 +141,11 @@ def delete_ts(module, fusion):
     ts_api_instance = purefusion.TenantSpacesApi(fusion)
     if not module.check_mode:
         try:
-            ts_api_instance.delete_tenant_space(
+            op = ts_api_instance.delete_tenant_space(
                 tenant_name=module.params["tenant"],
                 tenant_space_name=module.params["name"],
             )
+            await_operation(module, fusion, op)
         except purefusion.rest.ApiException:
             module.fail_json(
                 msg="Delete Tenant Space {0} failed.".format(module.params["name"])


### PR DESCRIPTION
##### SUMMARY
Some REST API calls (typically most create/update/delete operations) return an Operation ID and the resource is not changed until the Operation finishes. This Operation ID has to be continually polled to find out if it has finished. The collection did not do so, which could cause race conditions in playbook flow. This commit now manually awaits all relevant Operations before the logic proceeds.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
(almost) all modules

##### ADDITIONAL INFORMATION
All of the API call Operations are manually awaited. This is a quick fix that works for now, but may be potentially hard to maintain because it will be prone to miss on code changes and break on updates. Could be solved in the underlying Fusion Python SDK via custom generator extensions or via some custom linting step. Future task.