### PR TITLE
fusion_info - fix empty response for the placements parameter.

### DIFF
--- a/changelogs/fragments/PR62_fix_placements.yaml
+++ b/changelogs/fragments/PR62_fix_placements.yaml
@@ -1,0 +1,6 @@
+bugfixes:
+  - fusion_info - placements subset returned nothing. Now it collects the same information
+    as placement_groups subset (https://github.com/Pure-Storage-Ansible/Fusion-Collection/pull/62).
+deprecated_features:
+  - fusion_info - placements subset is deprecated in favor of placement_groups and will be removed
+    in the version 1.7.0 (https://github.com/Pure-Storage-Ansible/Fusion-Collection/pull/62).

--- a/plugins/modules/fusion_info.py
+++ b/plugins/modules/fusion_info.py
@@ -889,8 +889,12 @@ def main():
         info["volumes"] = generate_volumes_dict(fusion)
     if "protection_policies" in subset or "all" in subset:
         info["protection_policies"] = generate_pp_dict(fusion)
-    if "placement_groups" in subset or "all" in subset:
+    if "placement_groups" in subset or "all" in subset or "placements" in subset:
         info["placement_groups"] = generate_pg_dict(fusion)
+        if "placements" in subset:
+            module.warn(
+                "The 'placements' subset is deprecated and will be removed in the version 1.7.0"
+            )
     if "storage_classes" in subset or "all" in subset:
         info["storageclass"] = generate_storageclass_dict(fusion)
     if "interfaces" in subset or "all" in subset:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The response was empty for the placements parameter. Now it returns the same as placement_groups.Also, marked it as deprecated in favor of placement_groups.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
fusion_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
changelog fragment

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
bugfixes:
  - fusion_info - placements subset returned nothing. Now it collects the same information
    as placement_groups subset (https://github.com/Pure-Storage-Ansible/Fusion-Collection/pull/62).
deprecated_features:
  - fusion_info - placements subset is deprecated in favor of placement_groups and will be removed
    in the version 1.7.0 (https://github.com/Pure-Storage-Ansible/Fusion-Collection/pull/62).
```
