### PR TITLE
Change required Python version to 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Pure Storage Fusion collection consists of the latest versions of the Fusion
 ## Requirements
 
 - ansible-core >= 2.11
-- Python >= 3.5
+- Python >= 3.8
 - Authorized API Application ID for Pure Storage Pure1 and associated Private Key
   - Refer to Pure Storage documentation on how to create these. 
 - purefusion >= 1.0.4

--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -38,6 +38,6 @@ notes:
   - You must set C(FUSION_APP_ID) and C(FUSION_PRIVATE_KEY_FILE) environment variables
     if I(app_id) and I(key_file) arguments are not passed to the module directly
 requirements:
-  - python >= 3.5
+  - python >= 3.8
   - purefusion
 """


### PR DESCRIPTION
##### SUMMARY
Dropping support for python 3.5, 3.6, 3.7 as they are [end-of-life version](https://devguide.python.org/versions/) (or will be in several months in case of Python 3.7). Not supporting these versions doesn't mean the Ansible Collection won't run on the older version, but it will allow the developers to use features of Python 3.6, 3.7 and 3.8. Unless there is a business case for one of the mentioned versions, it's best to drop the support now while the module isn't widely used - now we're starting the development is the best time.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- Python version requirements

##### ADDITIONAL INFORMATION
Benefits of dropping support for older version:
- enable developers to use features introduces in Python [3.6](https://docs.python.org/3/whatsnew/3.6.html), [3.7](https://docs.python.org/3/whatsnew/3.7.html) and [3.8](https://docs.python.org/3/whatsnew/3.8.html)
- easier maintenance

Risks of supporting old versions:
- with time it will be increasingly complicated to drop support for old Python versions as more users will use this module
- third-party libraries may stop supporting it
- slower developer workflow
- security issues
