### PR TITLE
Fix typo in fusion_info

### DIFF
--- a/changelogs/fragments/70_fix_typo_appiances.yaml
+++ b/changelogs/fragments/70_fix_typo_appiances.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fusion_info - fixes typo in output 'appiiances' -> 'appliances'

--- a/plugins/modules/fusion_info.py
+++ b/plugins/modules/fusion_info.py
@@ -202,7 +202,7 @@ def generate_default_dict(fusion):
                 ).items
             )
             arrays = arrays + len(array_details.items)
-    default_info["appiiances"] = arrays
+    default_info["appliances"] = arrays
     default_info["network_interfaces"] = nics
     default_info["network_interface_groups"] = nigs
 


### PR DESCRIPTION
##### SUMMARY
Simple typo fix in one of the output fields, 'appiiances' -> 'appliances'.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fusion_info

##### ADDITIONAL INFORMATION
None.
