### PR TITLE
get_nifg broken because was still using provider_subnet

### DIFF
--- a/changelogs/fragments/72_fix_typo_getnifg.yaml
+++ b/changelogs/fragments/72_fix_typo_getnifg.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fusion_se - fix call in get_nifg where provider_subnet was used instead of network_interface_group_name

--- a/plugins/modules/fusion_se.py
+++ b/plugins/modules/fusion_se.py
@@ -134,7 +134,7 @@ def get_nifg(module, fusion):
             nifg_api_instance.get_network_interface_group(
                 region_name=module.params["region"],
                 availability_zone_name=module.params["availability_zone"],
-                provider_subnet=module.params["network_interface_groups"][group],
+                network_interface_group_name=module.params["network_interface_groups"][group],
             )
         except purefusion.rest.ApiException:
             return False

--- a/plugins/modules/fusion_se.py
+++ b/plugins/modules/fusion_se.py
@@ -134,7 +134,9 @@ def get_nifg(module, fusion):
             nifg_api_instance.get_network_interface_group(
                 region_name=module.params["region"],
                 availability_zone_name=module.params["availability_zone"],
-                network_interface_group_name=module.params["network_interface_groups"][group],
+                network_interface_group_name=module.params["network_interface_groups"][
+                    group
+                ],
             )
         except purefusion.rest.ApiException:
             return False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes issue where get_nifg broke because it was still using the previous argument name of provider_subnet, instead of the new name network_interface_group_name
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/fusion_se.py
