### PR TITLE
Minor bugfix to fusion_pp

### DIFF
--- a/changelogs/fragments/73_fix_missing_module_params.yaml
+++ b/changelogs/fragments/73_fix_missing_module_params.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fusion_pp - fix call to parse_minutes where we were missing a required argument

--- a/plugins/modules/fusion_pp.py
+++ b/plugins/modules/fusion_pp.py
@@ -117,7 +117,7 @@ def create_pp(module, fusion):
     """Create Protection Policy"""
 
     pp_api_instance = purefusion.ProtectionPoliciesApi(fusion)
-    local_retention = parse_minutes(module.params["local_retention"])
+    local_retention = parse_minutes(module, module.params["local_retention"])
     if local_retention < 1:
         module.fail_json(msg="Local Retention must be a minimum of 1 minutes")
     if module.params["local_rpo"] < 10:


### PR DESCRIPTION
##### SUMMARY
Fixes issue in fusion_pp where we were missing a required argument when calling parse_minutes, causing create_pp to fail to create protection policy

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/fusion_pp.py
