### PR TITLE
fusion_se: update module parameters to allow specification of discove…

### DIFF
--- a/changelogs/fragments/88_deprecate parameters in fusion_se.yaml
+++ b/changelogs/fragments/88_deprecate parameters in fusion_se.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - fusion_se - parameters "addresses", "gateway" and "network_interface_groups" are deprecated in favor of "iscsi" and will be removed in version 2.0.0

--- a/plugins/modules/fusion_se.py
+++ b/plugins/modules/fusion_se.py
@@ -53,13 +53,36 @@ options:
     type: str
     default: iscsi
     choices: [ iscsi ]
+  iscsi:
+    description:
+    - List of discovery interfaces.
+    type: list
+    elements: dict
+    suboptions:
+      address:
+        description:
+        - IP address to be used in the subnet of the storage endpoint.
+        - IP address must include a CIDR notation.
+        - Only IPv4 is supported at the moment.
+        type: str
+      gateway:
+        description:
+        - Address of the subnet gateway.
+        type: str
+      network_interface_groups:
+        description:
+        - List of network interface groups to assign to the address.
+        type: list
+        elements: str
   network_interface_groups:
     description:
+    - "DEPRECATED: Will be removed in version 2.0.0"
     - List of network interface groups to assign to the storage endpoints.
     type: list
     elements: str
   addresses:
     description:
+    - "DEPRECATED: Will be removed in version 2.0.0"
     - List of IP addresses to be used in the subnet of the storage endpoint.
     - IP addresses must include a CIDR notation.
     - Only IPv4 is supported at the moment.
@@ -67,15 +90,45 @@ options:
     elements: str
   gateway:
     description:
+    - "DEPRECATED: Will be removed in version 2.0.0"
     - Address of the subnet gateway.
     - Currently this must be provided.
     type: str
+
 extends_documentation_fragment:
 - purestorage.fusion.purestorage.fusion
 """
 
 EXAMPLES = r"""
 - name: Create new storage endpoint foo in AZ bar
+  purestorage.fusion.fusion_se:
+    name: foo
+    availability_zone: bar
+    region: us-west
+    iscsi:
+      - address: 10.21.200.124/24
+        gateway: 10.21.200.1
+        network_interface_groups:
+          - subnet-0
+      - address: 10.21.200.36/24
+        gateway: 10.21.200.2
+        network_interface_groups:
+          - subnet-0
+          - subnet-1
+    state: present
+    app_id: key_name
+    key_file: "az-admin-private-key.pem"
+
+- name: Delete storage endpoint foo in AZ bar
+  purestorage.fusion.fusion_se:
+    name: foo
+    availability_zone: bar
+    region: us-west
+    state: absent
+    app_id: key_name
+    key_file: "az-admin-private-key.pem"
+
+- name: (DEPRECATED) Create new storage endpoint foo in AZ bar
   purestorage.fusion.fusion_se:
     name: foo
     availability_zone: bar
@@ -87,15 +140,6 @@ EXAMPLES = r"""
     network_interface_groups:
       - subnet-0
     state: present
-    app_id: key_name
-    key_file: "az-admin-private-key.pem"
-
-- name: Delete storage endpoint foo in AZ bar
-  purestorage.fusion.fusion_se:
-    name: foo
-    availability_zone: bar
-    region: us-west
-    state: absent
     app_id: key_name
     key_file: "az-admin-private-key.pem"
 """
@@ -126,6 +170,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.operations impo
 )
 
 
+#######################################################################
+# DEPRECATED CODE SECTION STARTS
+
+
 def get_nifg(module, fusion):
     """Check all Network Interface Groups"""
     nifg_api_instance = purefusion.NetworkInterfaceGroupsApi(fusion)
@@ -143,32 +191,7 @@ def get_nifg(module, fusion):
     return True
 
 
-def get_az(module, fusion):
-    """Availability Zone or None"""
-    az_api_instance = purefusion.AvailabilityZonesApi(fusion)
-    try:
-        return az_api_instance.get_availability_zone(
-            availability_zone_name=module.params["availability_zone"],
-            region_name=module.params["region"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_se(module, fusion):
-    """Storage Endpoint or None"""
-    se_api_instance = purefusion.StorageEndpointsApi(fusion)
-    try:
-        return se_api_instance.get_storage_endpoint(
-            region_name=module.params["region"],
-            storage_endpoint_name=module.params["name"],
-            availability_zone_name=module.params["availability_zone"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def create_se(module, fusion):
+def create_se_old(module, fusion):
     """Create Storage Endpoint"""
 
     se_api_instance = purefusion.StorageEndpointsApi(fusion)
@@ -212,9 +235,80 @@ def create_se(module, fusion):
     module.exit_json(changed=changed)
 
 
+# DEPRECATED CODE SECTION ENDS
+#######################################################################
+
+
+def check_nifgs_exist(module, fusion):
+    """Check all Network Interface Groups exist"""
+    nifg_api_instance = purefusion.NetworkInterfaceGroupsApi(fusion)
+    for endpoint in module.params["iscsi"]:
+        for nig in endpoint["network_interface_groups"]:
+            try:
+                nifg_api_instance.get_network_interface_group(
+                    region_name=module.params["region"],
+                    availability_zone_name=module.params["availability_zone"],
+                    network_interface_group_name=nig,
+                )
+            except purefusion.rest.ApiException:
+                return False
+    return True
+
+
+def get_az(module, fusion):
+    """Availability Zone or None"""
+    az_api_instance = purefusion.AvailabilityZonesApi(fusion)
+    try:
+        return az_api_instance.get_availability_zone(
+            availability_zone_name=module.params["availability_zone"],
+            region_name=module.params["region"],
+        )
+    except purefusion.rest.ApiException:
+        return None
+
+
+def get_se(module, fusion):
+    """Storage Endpoint or None"""
+    se_api_instance = purefusion.StorageEndpointsApi(fusion)
+    try:
+        return se_api_instance.get_storage_endpoint(
+            region_name=module.params["region"],
+            storage_endpoint_name=module.params["name"],
+            availability_zone_name=module.params["availability_zone"],
+        )
+    except purefusion.rest.ApiException:
+        return None
+
+
+def create_se(module, fusion):
+    """Create Storage Endpoint"""
+    se_api_instance = purefusion.StorageEndpointsApi(fusion)
+
+    if not module.check_mode:
+        discovery_interfaces = [
+            purefusion.StorageEndpointIscsiDiscoveryInterfacePost(**endpoint)
+            for endpoint in module.params["iscsi"]
+        ]
+        storage_endpoint = purefusion.StorageEndpointPost(
+            name=module.params["name"],
+            display_name=module.params["display_name"] or module.params["name"],
+            endpoint_type=module.params["endpoint_type"],
+            iscsi=purefusion.StorageEndpointIscsiPost(
+                discovery_interfaces=discovery_interfaces
+            ),
+        )
+        op = se_api_instance.create_storage_endpoint(
+            storage_endpoint,
+            module.params["region"],
+            module.params["availability_zone"],
+        )
+        await_operation(module, fusion, op)
+
+    module.exit_json(changed=True)
+
+
 def delete_se(module, fusion):
     """Delete Storage Endpoint"""
-    changed = True
     se_api_instance = purefusion.StorageEndpointsApi(fusion)
     if not module.check_mode:
         op = se_api_instance.delete_storage_endpoint(
@@ -223,7 +317,7 @@ def delete_se(module, fusion):
             storage_endpoint_name=module.params["name"],
         )
         await_operation(module, fusion, op)
-    module.exit_json(changed=changed)
+    module.exit_json(changed=True)
 
 
 def update_se(module, fusion, se):
@@ -265,14 +359,47 @@ def main():
             region=dict(type="str", required=True),
             availability_zone=dict(type="str", required=True, aliases=["az"]),
             endpoint_type=dict(type="str", default="iscsi", choices=["iscsi"]),
-            addresses=dict(type="list", elements="str"),
-            gateway=dict(type="str"),
-            network_interface_groups=dict(type="list", elements="str"),
+            iscsi=dict(
+                type="list",
+                elements="dict",
+                options=dict(
+                    address=dict(type="str"),
+                    gateway=dict(type="str"),
+                    network_interface_groups=dict(type="list", elements="str"),
+                ),
+            ),
             state=dict(type="str", default="present", choices=["absent", "present"]),
+            # deprecated, will be removed in 2.0.0
+            addresses=dict(
+                type="list",
+                elements="str",
+                removed_in_version="2.0.0",
+                removed_from_collection="purestorage.fusion",
+            ),
+            gateway=dict(
+                type="str",
+                removed_in_version="2.0.0",
+                removed_from_collection="purestorage.fusion",
+            ),
+            network_interface_groups=dict(
+                type="list",
+                elements="str",
+                removed_in_version="2.0.0",
+                removed_from_collection="purestorage.fusion",
+            ),
         )
     )
 
-    module = AnsibleModule(argument_spec, supports_check_mode=True)
+    # can not use both deprecated and new fields at the same time
+    mutually_exclusive = [
+        ("iscsi", "addresses"),
+        ("iscsi", "gateway"),
+        ("iscsi", "network_interface_groups"),
+    ]
+
+    module = AnsibleModule(
+        argument_spec, mutually_exclusive=mutually_exclusive, supports_check_mode=True
+    )
     install_fusion_exception_hook(module)
 
     state = module.params["state"]
@@ -283,30 +410,67 @@ def main():
                 module.params["availability_zone"]
             )
         )
-    if module.params["network_interface_groups"] and not get_nifg(module, fusion):
-        module.fail_json(
-            msg="Not all of the network interface groups exist in the specified AZ"
-        )
-    if module.params["addresses"]:
-        for address in module.params["addresses"]:
-            if not is_valid_network(address):
-                module.fail_json(
-                    msg="'{0}' is not a valid address in CIDR notation".format(address)
-                )
 
-    sendp = get_se(module, fusion)
+    deprecated_parameters = {"addresses", "gateway", "network_interface_groups"}
+    used_deprecated_parameters = list(deprecated_parameters & module.params.keys())
 
-    if state == "present" and not sendp:
-        module.fail_on_missing_params(["addresses"])
-        if not (module.params["addresses"]):
-            module.fail_json(
-                msg="At least one entry in 'addresses' is required to create new storage endpoint"
+    if len(used_deprecated_parameters) > 0:
+        # user uses deprecated module interface
+        for param_name in used_deprecated_parameters:
+            module.warn(
+                f"{param_name} is deprecated and will be removed in the version 2.0"
             )
-        create_se(module, fusion)
-    elif state == "present" and sendp:
-        update_se(module, fusion, sendp)
-    elif state == "absent" and sendp:
-        delete_se(module, fusion)
+
+        if module.params["network_interface_groups"] and not get_nifg(module, fusion):
+            module.fail_json(
+                msg="Not all of the network interface groups exist in the specified AZ"
+            )
+        if module.params["addresses"]:
+            for address in module.params["addresses"]:
+                if not is_valid_network(address):
+                    module.fail_json(
+                        msg="'{0}' is not a valid address in CIDR notation".format(
+                            address
+                        )
+                    )
+
+        sendp = get_se(module, fusion)
+
+        if state == "present" and not sendp:
+            module.fail_on_missing_params(["addresses"])
+            if not (module.params["addresses"]):
+                module.fail_json(
+                    msg="At least one entry in 'addresses' is required to create new storage endpoint"
+                )
+            create_se_old(module, fusion)
+        elif state == "present" and sendp:
+            update_se(module, fusion, sendp)
+        elif state == "absent" and sendp:
+            delete_se(module, fusion)
+    else:
+        # user uses new module interface
+        if not check_nifgs_exist(module, fusion):
+            module.fail_json(
+                msg="Not all of the network interface groups exist in the specified AZ"
+            )
+        if module.params["iscsi"]:
+            for endpoint in module.params["iscsi"]:
+                address = endpoint["address"]
+                if not is_valid_network(address):
+                    module.fail_json(
+                        msg="'{0}' is not a valid address in CIDR notation".format(
+                            address
+                        )
+                    )
+
+        sendp = get_se(module, fusion)
+
+        if state == "present" and not sendp:
+            create_se(module, fusion)
+        elif state == "present" and sendp:
+            update_se(module, fusion, sendp)
+        elif state == "absent" and sendp:
+            delete_se(module, fusion)
 
     module.exit_json(changed=False)
 


### PR DESCRIPTION
##### SUMMARY
Fusion Storage Endpoint module is not in parity with neither Pure Storage Fusion API nor purefusion Python SDK. This Pull Request propose an updated fusion_se module interface which corresponds to both Pure Storage Fusion API and Python examples in [fusion-client-devkit](https://github.com/PureStorage-OpenConnect/fusion-client-devkit).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fusion_se

##### ADDITIONAL INFORMATION
In [fusion-client-devkit](https://github.com/PureStorage-OpenConnect/fusion-client-devkit), we have examples for setting up infrastructure using purefusion Python SDK and our Ansible Collection.

Using Python, imagine, you want to set up Storage Endpoint with the following definition in `../infrastructure.yaml`:
```
    storage_endpoints:
    - name: Fusion-Storage-Point
      display_name: Fusion-Storage-Point
      endpoint_type: iscsi
      iscsi:
      - address: 192.0.0.1/22
        network_interface_groups:
        - subnet1
      - address: 192.0.0.2/22
        network_interface_groups:
        - subnet2
```
Note, that you want to use addresses _192.0.0.1/22_ and _192.0.0.2/22_ in two different network interface groups _subnet1_ and _subnet2_. This example works as expected.

If you want to achieve the same, but using Ansible, you can't really write a proper definition of the infrastructure in `../infrastructure.yaml`. You can do the following, but it won't work:
```
storage_endpoints:
  - name: Fusion-Storage-Point
    display_name: Fusion-Storage-Point
    endpoint_type: iscsi
    availability_zone: az1
    region: region1
    address: ["192.0.0.1/22", "192.0.0.2/22"]
    network_interface_groups: ["subnet1","subnet2"]
```
This would use addresses _192.0.0.1/22_ and _192.0.0.2/22_, but to both addresses, it would assign both network interface groups _subnet1_ and _subnet2_. In current state of the Ansible Collection, you cannot really define to which network interface group the address belongs.

This Pull Request propose an updated fusion_se module interface which corresponds to both Pure Storage Fusion API and Python examples in [fusion-client-devkit](https://github.com/PureStorage-OpenConnect/fusion-client-devkit).

Using the new fusion_se interface the above example can be rewritten to
```
storage_endpoints:
  - name: Fusion-Storage-Point
    display_name: Fusion-Storage-Point
    endpoint_type: iscsi
    availability_zone: az1
    region: region1
    iscsi:
      - address: 192.168.20.10/22
        network_interface_groups:
          - subnet1
      - address: 192.168.24.11/22
        network_interface_groups:
          - subnet2
```