### PR TITLE
Refactor and de-duplicate getters in Ansible modules

### DIFF
--- a/plugins/module_utils/getters.py
+++ b/plugins/module_utils/getters.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2023, Daniel Turecek (dturecek@purestorage.com)
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+try:
+    import fusion as purefusion
+except ImportError:
+    pass
+
+
+def get_array(module, fusion, array_name=None):
+    """Return Array or None"""
+    array_api_instance = purefusion.ArraysApi(fusion)
+    try:
+        if array_name is None:
+            array_name = module.params["array"]
+
+        return array_api_instance.get_array(
+            array_name=array_name,
+            availability_zone_name=module.params["availability_zone"],
+            region_name=module.params["region"],
+        )
+    except purefusion.rest.ApiException:
+        return None
+
+
+def get_az(module, fusion, availability_zone_name=None):
+    """Get Availability Zone or None"""
+    az_api_instance = purefusion.AvailabilityZonesApi(fusion)
+    try:
+        if availability_zone_name is None:
+            availability_zone_name = module.params["availability_zone"]
+
+        return az_api_instance.get_availability_zone(
+            region_name=module.params["region"],
+            availability_zone_name=availability_zone_name,
+        )
+    except purefusion.rest.ApiException:
+        return None
+
+
+def get_region(module, fusion, region_name=None):
+    """Get Region or None"""
+    region_api_instance = purefusion.RegionsApi(fusion)
+    try:
+        if region_name is None:
+            region_name = module.params["region"]
+
+        return region_api_instance.get_region(
+            region_name=region_name,
+        )
+    except purefusion.rest.ApiException:
+        return None
+
+
+def get_ss(module, fusion, storage_service_name=None):
+    """Return Storage Service or None"""
+    ss_api_instance = purefusion.StorageServicesApi(fusion)
+    try:
+        if storage_service_name is None:
+            storage_service_name = module.params["storage_service"]
+
+        return ss_api_instance.get_storage_service(
+            storage_service_name=storage_service_name
+        )
+    except purefusion.rest.ApiException:
+        return None
+
+
+def get_tenant(module, fusion, tenant_name=None):
+    """Return Tenant or None"""
+    api_instance = purefusion.TenantsApi(fusion)
+    try:
+        if tenant_name is None:
+            tenant_name = module.params["tenant"]
+
+        return api_instance.get_tenant(tenant_name=tenant_name)
+    except purefusion.rest.ApiException:
+        return None
+
+
+def get_ts(module, fusion, tenant_space_name=None):
+    """Tenant Space or None"""
+    ts_api_instance = purefusion.TenantSpacesApi(fusion)
+    try:
+        if tenant_space_name is None:
+            tenant_space_name = module.params["tenant_space"]
+
+        return ts_api_instance.get_tenant_space(
+            tenant_name=module.params["tenant"],
+            tenant_space_name=tenant_space_name,
+        )
+    except purefusion.rest.ApiException:
+        return None

--- a/plugins/modules/fusion_array.py
+++ b/plugins/modules/fusion_array.py
@@ -110,6 +110,7 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils import getters
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
@@ -120,15 +121,7 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
 
 def get_array(module, fusion):
     """Return Array or None"""
-    array_api_instance = purefusion.ArraysApi(fusion)
-    try:
-        return array_api_instance.get_array(
-            array_name=module.params["name"],
-            availability_zone_name=module.params["availability_zone"],
-            region_name=module.params["region"],
-        )
-    except purefusion.rest.ApiException:
-        return None
+    return getters.get_array(module, fusion, array_name=module.params["name"])
 
 
 def create_array(module, fusion):

--- a/plugins/modules/fusion_az.py
+++ b/plugins/modules/fusion_az.py
@@ -78,6 +78,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils import getters
+from ansible_collections.purestorage.fusion.plugins.module_utils.getters import (
+    get_region,
+)
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
@@ -88,25 +92,7 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
 
 def get_az(module, fusion):
     """Get Availability Zone or None"""
-    az_api_instance = purefusion.AvailabilityZonesApi(fusion)
-    try:
-        return az_api_instance.get_availability_zone(
-            availability_zone_name=module.params["name"],
-            region_name=module.params["region"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_region(module, fusion):
-    """Get Region or None"""
-    region_api_instance = purefusion.RegionsApi(fusion)
-    try:
-        return region_api_instance.get_region(
-            region_name=module.params["region"],
-        )
-    except purefusion.rest.ApiException:
-        return None
+    return getters.get_az(module, fusion, availability_zone_name=module.params["name"])
 
 
 def delete_az(module, fusion):

--- a/plugins/modules/fusion_ni.py
+++ b/plugins/modules/fusion_ni.py
@@ -94,6 +94,11 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     fusion_argument_spec,
 )
 
+from ansible_collections.purestorage.fusion.plugins.module_utils.getters import (
+    get_array,
+    get_az,
+    get_region,
+)
 from ansible_collections.purestorage.fusion.plugins.module_utils.networking import (
     is_valid_network,
 )
@@ -103,42 +108,6 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
-
-
-def get_region(module, fusion):
-    """Get Region or None"""
-    region_api_instance = purefusion.RegionsApi(fusion)
-    try:
-        return region_api_instance.get_region(
-            region_name=module.params["region"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_az(module, fusion):
-    """Get Availability Zone or None"""
-    az_api_instance = purefusion.AvailabilityZonesApi(fusion)
-    try:
-        return az_api_instance.get_availability_zone(
-            region_name=module.params["region"],
-            availability_zone_name=module.params["availability_zone"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_array(module, fusion):
-    """Return Array or None"""
-    array_api_instance = purefusion.ArraysApi(fusion)
-    try:
-        return array_api_instance.get_array(
-            region_name=module.params["region"],
-            availability_zone_name=module.params["availability_zone"],
-            array_name=module.params["array"],
-        )
-    except purefusion.rest.ApiException:
-        return None
 
 
 def get_ni(module, fusion):
@@ -205,7 +174,7 @@ def update_ni(module, fusion, ni):
                 array_name=module.params["array"],
                 net_intf_name=module.params["name"],
             )
-            await_operation(module, fusion, op)
+            await_operation(fusion, op)
 
     changed = len(patches) != 0
 

--- a/plugins/modules/fusion_nig.py
+++ b/plugins/modules/fusion_nig.py
@@ -120,6 +120,9 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.networking impo
 from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
     install_fusion_exception_hook,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils.getters import (
+    get_az,
+)
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
@@ -133,18 +136,6 @@ def get_nig(module, fusion):
             availability_zone_name=module.params["availability_zone"],
             region_name=module.params["region"],
             network_interface_group_name=module.params["name"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_az(module, fusion):
-    """Availability Zone or None"""
-    az_api_instance = purefusion.AvailabilityZonesApi(fusion)
-    try:
-        return az_api_instance.get_availability_zone(
-            availability_zone_name=module.params["availability_zone"],
-            region_name=module.params["region"],
         )
     except purefusion.rest.ApiException:
         return None

--- a/plugins/modules/fusion_pg.py
+++ b/plugins/modules/fusion_pg.py
@@ -119,42 +119,14 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
 from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
     install_fusion_exception_hook,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils.getters import (
+    get_az,
+    get_tenant,
+    get_ts,
+)
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
-
-
-def get_ts(module, fusion):
-    """Tenant Space or None"""
-    ts_api_instance = purefusion.TenantSpacesApi(fusion)
-    try:
-        return ts_api_instance.get_tenant_space(
-            tenant_name=module.params["tenant"],
-            tenant_space_name=module.params["tenant_space"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_az(module, fusion):
-    """Availability Zone or None"""
-    api_instance = purefusion.AvailabilityZonesApi(fusion)
-    try:
-        return api_instance.get_availability_zone(
-            availability_zone_name=module.params["availability_zone"],
-            region_name=module.params["region"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_tenant(module, fusion):
-    """Return Tenant or None"""
-    api_instance = purefusion.TenantsApi(fusion)
-    try:
-        return api_instance.get_tenant(tenant_name=module.params["tenant"])
-    except purefusion.rest.ApiException:
-        return None
 
 
 def get_pg(module, fusion):

--- a/plugins/modules/fusion_ra.py
+++ b/plugins/modules/fusion_ra.py
@@ -98,6 +98,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.operations impo
 from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
     install_fusion_exception_hook,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils.getters import (
+    get_tenant,
+    get_ts,
+)
 
 
 def human_to_principal(fusion, user_id):
@@ -154,27 +158,6 @@ def get_ra(module, fusion):
             ):
                 return assignments[assign]
         return None
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_tenant(module, fusion):
-    """Return tenant or None"""
-    t_api_instance = purefusion.TenantsApi(fusion)
-    try:
-        return t_api_instance.get_tenant(tenant_name=module.params["tenant"])
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_ts(module, fusion):
-    """Return tenant space or None"""
-    ts_api_instance = purefusion.TenantSpacesApi(fusion)
-    try:
-        return ts_api_instance.get_tenant_space(
-            tenant_space_name=module.params["tenant_space"],
-            tenant_name=module.params["tenant"],
-        )
     except purefusion.rest.ApiException:
         return None
 

--- a/plugins/modules/fusion_region.py
+++ b/plugins/modules/fusion_region.py
@@ -84,17 +84,12 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.operations impo
 from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
     install_fusion_exception_hook,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils import getters
 
 
 def get_region(module, fusion):
     """Get Region or None"""
-    region_api_instance = purefusion.RegionsApi(fusion)
-    try:
-        return region_api_instance.get_region(
-            region_name=module.params["name"],
-        )
-    except purefusion.rest.ApiException:
-        return None
+    return getters.get_region(module, fusion, module.params["name"])
 
 
 def create_region(module, fusion):

--- a/plugins/modules/fusion_sc.py
+++ b/plugins/modules/fusion_sc.py
@@ -117,6 +117,9 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.parsing import 
 from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
     install_fusion_exception_hook,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils.getters import (
+    get_ss,
+)
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
@@ -129,17 +132,6 @@ def get_sc(module, fusion):
         return sc_api_instance.get_storage_class(
             storage_class_name=module.params["name"],
             storage_service_name=module.params["storage_service"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_ss(module, fusion):
-    """Return Storage Service or None"""
-    ss_api_instance = purefusion.StorageServicesApi(fusion)
-    try:
-        return ss_api_instance.get_storage_service(
-            storage_service_name=module.params["storage_service"]
         )
     except purefusion.rest.ApiException:
         return None

--- a/plugins/modules/fusion_se.py
+++ b/plugins/modules/fusion_se.py
@@ -165,6 +165,9 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.networking impo
 from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
     install_fusion_exception_hook,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils.getters import (
+    get_az,
+)
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
@@ -255,18 +258,6 @@ def check_nifgs_exist(module, fusion):
     return True
 
 
-def get_az(module, fusion):
-    """Availability Zone or None"""
-    az_api_instance = purefusion.AvailabilityZonesApi(fusion)
-    try:
-        return az_api_instance.get_availability_zone(
-            availability_zone_name=module.params["availability_zone"],
-            region_name=module.params["region"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
 def get_se(module, fusion):
     """Storage Endpoint or None"""
     se_api_instance = purefusion.StorageEndpointsApi(fusion)
@@ -302,7 +293,7 @@ def create_se(module, fusion):
             module.params["region"],
             module.params["availability_zone"],
         )
-        await_operation(module, fusion, op)
+        await_operation(fusion, op)
 
     module.exit_json(changed=True)
 

--- a/plugins/modules/fusion_ss.py
+++ b/plugins/modules/fusion_ss.py
@@ -92,6 +92,7 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
 from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
     install_fusion_exception_hook,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils import getters
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
@@ -99,13 +100,7 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.operations impo
 
 def get_ss(module, fusion):
     """Return Storage Service or None"""
-    ss_api_instance = purefusion.StorageServicesApi(fusion)
-    try:
-        return ss_api_instance.get_storage_service(
-            storage_service_name=module.params["name"]
-        )
-    except purefusion.rest.ApiException:
-        return None
+    return getters.get_ss(module, fusion, storage_service_name=module.params["name"])
 
 
 def create_ss(module, fusion):

--- a/plugins/modules/fusion_tenant.py
+++ b/plugins/modules/fusion_tenant.py
@@ -73,6 +73,7 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
 from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
     install_fusion_exception_hook,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils import getters
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
@@ -80,11 +81,7 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.operations impo
 
 def get_tenant(module, fusion):
     """Return Tenant or None"""
-    api_instance = purefusion.TenantsApi(fusion)
-    try:
-        return api_instance.get_tenant(tenant_name=module.params["name"])
-    except purefusion.rest.ApiException:
-        return None
+    return getters.get_tenant(module, fusion, tenant_name=module.params["name"])
 
 
 def create_tenant(module, fusion):

--- a/plugins/modules/fusion_tn.py
+++ b/plugins/modules/fusion_tn.py
@@ -129,6 +129,9 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
     get_fusion,
     fusion_argument_spec,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils.getters import (
+    get_az,
+)
 
 
 def get_ps(module, fusion):
@@ -143,18 +146,6 @@ def get_ps(module, fusion):
         except purefusion.rest.ApiException:
             return False
     return True
-
-
-def get_az(module, fusion):
-    """Availability Zone or None"""
-    az_api_instance = purefusion.AvailabilityZonesApi(fusion)
-    try:
-        return az_api_instance.get_availability_zone(
-            availability_zone_name=module.params["availability_zone"],
-            region_name=module.params["region"],
-        )
-    except purefusion.rest.ApiException:
-        return None
 
 
 def get_tn(module, fusion):

--- a/plugins/modules/fusion_ts.py
+++ b/plugins/modules/fusion_ts.py
@@ -80,6 +80,10 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
 from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
     install_fusion_exception_hook,
 )
+from ansible_collections.purestorage.fusion.plugins.module_utils import getters
+from ansible_collections.purestorage.fusion.plugins.module_utils.getters import (
+    get_tenant,
+)
 from ansible_collections.purestorage.fusion.plugins.module_utils.operations import (
     await_operation,
 )
@@ -87,23 +91,7 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.operations impo
 
 def get_ts(module, fusion):
     """Tenant Space or None"""
-    ts_api_instance = purefusion.TenantSpacesApi(fusion)
-    try:
-        return ts_api_instance.get_tenant_space(
-            tenant_name=module.params["tenant"],
-            tenant_space_name=module.params["name"],
-        )
-    except purefusion.rest.ApiException:
-        return None
-
-
-def get_tenant(module, fusion):
-    """Return Tenant or None"""
-    api_instance = purefusion.TenantsApi(fusion)
-    try:
-        return api_instance.get_tenant(tenant_name=module.params["tenant"])
-    except purefusion.rest.ApiException:
-        return None
+    return getters.get_ts(module, fusion, tenant_space_name=module.params["name"])
 
 
 def create_ts(module, fusion):


### PR DESCRIPTION
##### SUMMARY
Refactored duplicated getter functions in modules so that they are defined only in one place

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- fusion_array.py
- fusion_az.py
- fusion_ni.py
- fusion_nig.py
- fusion_pg.py
- fusion_ra.py
- fusion_region.py
- fusion_sc.py
- fusion_se.py
- fusion_ss.py
- fusion_tenant.py
- fusion_tn.py
- fusion_ts.py
- fusion_volume.py

##### ADDITIONAL INFORMATION
-  Testing - run playbook for each module
