### PR TITLE
Update protection policy retention description

### DIFF
--- a/changelogs/99_update_protection_policy_retention_description.yaml
+++ b/changelogs/99_update_protection_policy_retention_description.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fusion_pp - updated retention description

--- a/plugins/modules/fusion_pp.py
+++ b/plugins/modules/fusion_pp.py
@@ -46,11 +46,10 @@ options:
   local_retention:
     description:
     - Retention Duration for periodic snapshots.
-    - Minimum value is 1 minute.
+    - Minimum value is 10 minutes.
     - Value can be provided as m(inutes), h(ours),
       d(ays), w(eeks), or y(ears).
     - If no unit is provided, minutes are assumed.
-    - Must be between 1MB/s and 512GB/s.
     type: str
     required: true
 extends_documentation_fragment:


### PR DESCRIPTION
##### SUMMARY

Updated `local_retention` description in Protection Policy module.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
`fusion_pp.py`
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
`Must be between 1MB/s and 512GB/s` is more appropriate to bandwidth limit and it looks like it was copied by mistake (from [here](https://github.com/Pure-Storage-Ansible/Fusion-Collection/blob/master/plugins/modules/fusion_sc.py#L52)), so removing it.
Minimal retention is 10 minutes according to frontdoor validations, so updating it.

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->

