### PR TITLE
Set HAP Display Name default value

### DIFF
--- a/changelogs/fragments/102_set_hap_display_name_default_value.yaml
+++ b/changelogs/fragments/102_set_hap_display_name_default_value.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fusion_hap - display name has now default value set to the value of name

--- a/plugins/modules/fusion_hap.py
+++ b/plugins/modules/fusion_hap.py
@@ -166,12 +166,14 @@ def create_hap(module, fusion):
     hap_api_instance = purefusion.HostAccessPoliciesApi(fusion)
     changed = True
     if not module.check_mode:
+        display_name = module.params["display_name"] or module.params["name"]
+
         op = hap_api_instance.create_host_access_policy(
             purefusion.HostAccessPoliciesPost(
                 iqn=module.params["iqn"],
                 personality=module.params["personality"],
                 name=module.params["name"],
-                display_name=module.params["display_name"],
+                display_name=display_name,
             )
         )
         await_operation(fusion, op)


### PR DESCRIPTION
##### SUMMARY
Sets the default value of HAP Display name to the value of name

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fusion_hap

##### ADDITIONAL INFORMATION

