### PR TITLE
Correct required parameters in all modules

### DIFF
--- a/changelogs/fragments/103_correct_required_parameters_in_all_modules.yaml
+++ b/changelogs/fragments/103_correct_required_parameters_in_all_modules.yaml
@@ -4,4 +4,4 @@ bugfixes:
   - fusion_pg - correct required parameters
   - fusion_pp - correct required parameters
   - fusion_sc - correct required parameters
-  - fusion_ss - correct required parameters
+  - fusion_ss - allow updating hardware types, correct required parameters

--- a/changelogs/fragments/103_correct_required_parameters_in_all_modules.yaml
+++ b/changelogs/fragments/103_correct_required_parameters_in_all_modules.yaml
@@ -1,0 +1,7 @@
+bugfixes:
+  - fusion_array - correct required parameters
+  - fusion_hw - correct required parameters
+  - fusion_pg - correct required parameters
+  - fusion_pp - correct required parameters
+  - fusion_sc - correct required parameters
+  - fusion_ss - correct required parameters

--- a/plugins/module_utils/parsing.py
+++ b/plugins/module_utils/parsing.py
@@ -50,7 +50,7 @@ def parse_duration(period):
         return int(period)
 
     match = duration_pattern.match(period.upper())
-    if not match:
+    if not match or period == "":
         raise ValueError("Invalid format")
 
     durations = {

--- a/plugins/modules/fusion_array.py
+++ b/plugins/modules/fusion_array.py
@@ -51,17 +51,14 @@ options:
     description:
     - Hardware type to which the storage class applies.
     choices: [ flash-array-x, flash-array-c, flash-array-x-optane, flash-array-xl ]
-    required: true
     type: str
   host_name:
     description:
     - Management IP address of the array, or FQDN.
-    required: true
     type: str
   appliance_id:
     description:
     - Appliance ID of the array.
-    required: true
     type: str
   maintenance_mode:
     description:
@@ -227,11 +224,10 @@ def main():
             availability_zone=dict(type="str", required=True, aliases=["az"]),
             display_name=dict(type="str"),
             region=dict(type="str", required=True),
-            appliance_id=dict(type="str", required=True),
-            host_name=dict(type="str", required=True),
+            appliance_id=dict(type="str"),
+            host_name=dict(type="str"),
             hardware_type=dict(
                 type="str",
-                required=True,
                 choices=[
                     "flash-array-x",
                     "flash-array-c",
@@ -254,6 +250,7 @@ def main():
 
     changed = False
     if not array and state == "present":
+        module.fail_on_missing_params(["hardware_type", "host_name", "appliance_id"])
         changed = create_array(module, fusion) | update_array(
             module, fusion
         )  # update is run to set properties which cannot be set on creation and instead use defaults

--- a/plugins/modules/fusion_hw.py
+++ b/plugins/modules/fusion_hw.py
@@ -28,7 +28,6 @@ options:
     description:
     - The name of the hardware type.
     type: str
-    required: true
   state:
     description:
     - Define whether the hardware type should exist or not.
@@ -45,26 +44,17 @@ options:
     description:
     - Volume size limit in M, G, T or P units.
     type: str
-    required: true
   array_type:
     description:
     - The array type for the hardware type.
     choices: [ FA//X, FA//C ]
     type: str
-    required: true
 extends_documentation_fragment:
 - purestorage.fusion.purestorage.fusion
 """
 
+# this module does nothing, thus no example is provided
 EXAMPLES = r"""
-- name: Create new hardware type foo
-  purestorage.fusion.fusion_hw:
-    name: foo
-    array_type: "FA//X"
-    media_type: NVME
-    display_name: "NVME arrays"
-    app_id: key_name
-    key_file: "az-admin-private-key.pem"
 """
 
 RETURN = r"""
@@ -81,10 +71,10 @@ def main():
     argument_spec = fusion_argument_spec()
     argument_spec.update(
         dict(
-            name=dict(type="str", required=True),
+            name=dict(type="str"),
             display_name=dict(type="str"),
-            array_type=dict(type="str", choices=["FA//X", "FA//C"], required=True),
-            media_type=dict(type="str", required=True),
+            array_type=dict(type="str", choices=["FA//X", "FA//C"]),
+            media_type=dict(type="str"),
             state=dict(type="str", default="present", choices=["present"]),
         )
     )

--- a/plugins/modules/fusion_pp.py
+++ b/plugins/modules/fusion_pp.py
@@ -42,7 +42,6 @@ options:
     - Value should be specified in minutes.
     - Minimum value is 10 minutes.
     type: int
-    required: true
   local_retention:
     description:
     - Retention Duration for periodic snapshots.
@@ -51,7 +50,6 @@ options:
       d(ays), w(eeks), or y(ears).
     - If no unit is provided, minutes are assumed.
     type: str
-    required: true
 extends_documentation_fragment:
 - purestorage.fusion.purestorage.fusion
 """
@@ -168,8 +166,8 @@ def main():
         dict(
             name=dict(type="str", required=True),
             display_name=dict(type="str"),
-            local_rpo=dict(type="int", required=True),
-            local_retention=dict(type="str", required=True),
+            local_rpo=dict(type="int"),
+            local_retention=dict(type="str"),
             state=dict(type="str", default="present", choices=["present", "absent"]),
         )
     )
@@ -181,6 +179,7 @@ def main():
     policy = get_pp(module, fusion)
 
     if not policy and state == "present":
+        module.fail_on_missing_params(["local_rpo", "local_retention"])
         create_pp(module, fusion)
     elif policy and state == "absent":
         delete_pp(module, fusion)

--- a/plugins/modules/fusion_sc.py
+++ b/plugins/modules/fusion_sc.py
@@ -64,6 +64,7 @@ options:
     description:
     - Storage service to which the storage class belongs.
     type: str
+    required: true
 extends_documentation_fragment:
 - purestorage.fusion.purestorage.fusion
 """
@@ -84,6 +85,7 @@ EXAMPLES = r"""
   purestorage.fusion.fusion_sc:
     name: foo
     display_name: "main class"
+    storage_service: service1
     app_id: key_name
     key_file: "az-admin-private-key.pem"
 
@@ -235,7 +237,7 @@ def main():
             iops_limit=dict(type="str"),
             bw_limit=dict(type="str"),
             size_limit=dict(type="str"),
-            storage_service=dict(type="str"),
+            storage_service=dict(type="str", required=True),
             state=dict(type="str", default="present", choices=["present", "absent"]),
         )
     )

--- a/plugins/modules/fusion_ss.py
+++ b/plugins/modules/fusion_ss.py
@@ -153,6 +153,16 @@ def update_ss(module, fusion, ss):
         )
         patches.append(patch)
 
+    if module.params["hardware_types"] and sorted(
+        module.params["hardware_types"]
+    ) != sorted(ss.hardware_types):
+        patch = purefusion.StorageServicePatch(
+            hardware_types=purefusion.NullableStringArray(
+                module.params["hardware_types"]
+            ),
+        )
+        patches.append(patch)
+
     if not module.check_mode:
         for patch in patches:
             op = ss_api_instance.update_storage_service(

--- a/plugins/modules/fusion_ss.py
+++ b/plugins/modules/fusion_ss.py
@@ -39,7 +39,6 @@ options:
   hardware_types:
     description:
     - Hardware types to which the storage service applies.
-    required: true
     type: list
     elements: str
     choices: [ flash-array-x, flash-array-c, flash-array-x-optane, flash-array-xl ]
@@ -176,7 +175,6 @@ def main():
             display_name=dict(type="str"),
             hardware_types=dict(
                 type="list",
-                required=True,
                 elements="str",
                 choices=[
                     "flash-array-x",
@@ -197,6 +195,7 @@ def main():
     s_service = get_ss(module, fusion)
 
     if not s_service and state == "present":
+        module.fail_on_missing_params(["hardware_types"])
         create_ss(module, fusion)
     elif s_service and state == "present":
         update_ss(module, fusion, s_service)

--- a/tests/integration/targets/fusion_pg/tasks/main.yml
+++ b/tests/integration/targets/fusion_pg/tasks/main.yml
@@ -54,9 +54,6 @@
     name: foo_pg
     tenant: foo_tenant
     tenant_space: foo_tenant_space
-    region: pure-us-west
-    availability_zone: az1
-    storage_service: foo_service
     state: absent
   register: result
   environment: "{{ test_env }}"
@@ -82,8 +79,6 @@
   purestorage.fusion.fusion_ss:
     name: foo_service
     state: absent
-    hardware_types:
-      - flash-array-x
   environment: "{{ test_env }}"
 
 - name: Delete foo_tenant_space

--- a/tests/integration/targets/fusion_pp/tasks/main.yml
+++ b/tests/integration/targets/fusion_pp/tasks/main.yml
@@ -24,8 +24,6 @@
 - name: Delete protection policy foo_pp
   purestorage.fusion.fusion_pp:
     name: foo_pp
-    local_rpo: 10
-    local_retention: 4d
     state: absent
   register: result
   environment: "{{ test_env }}"

--- a/tests/integration/targets/fusion_sc/tasks/main.yml
+++ b/tests/integration/targets/fusion_sc/tasks/main.yml
@@ -78,8 +78,6 @@
   purestorage.fusion.fusion_ss:
     name: foo_service
     state: absent
-    hardware_types:
-      - flash-array-x
   environment: "{{ test_env }}"
 
 - name: Delete foo_tenant_space

--- a/tests/integration/targets/fusion_ss/tasks/main.yml
+++ b/tests/integration/targets/fusion_ss/tasks/main.yml
@@ -43,8 +43,6 @@
   purestorage.fusion.fusion_ss:
     name: foo_service
     state: absent
-    hardware_types:
-      - flash-array-x
   register: result
   environment: "{{ test_env }}"
 - name: Validate the task

--- a/tests/unit/mocks/module_mock.py
+++ b/tests/unit/mocks/module_mock.py
@@ -19,18 +19,20 @@ class ModuleFailed(Exception):
 
 
 class ModuleMock(MagicMock):
-    def __init__(self, params, check_mode=False, exit_json=None, fail_json=None):
+    def __init__(self, params, check_mode=False):
         super().__init__()
 
         self.params = params
         self.check_mode = check_mode
 
-        if exit_json is None:
-            self.exit_json = MagicMock()
-        else:
-            self.exit_json = exit_json
+        # mocking exit_json function, so we can check if it was successfully called
+        self.exit_json = MagicMock()
 
-        if fail_json is None:
-            self.fail_json = MagicMock()
-        else:
-            self.fail_json = fail_json
+    def fail_json(self, **kwargs):
+        raise ModuleFailed(str(kwargs))
+
+    def fail_on_missing_params(self, required_params=None):
+        if required_params is not None:
+            for param in required_params:
+                if param not in self.params:
+                    raise ModuleFailed(f"Parameter '{param}' is missing")

--- a/tests/unit/modules/test_fusion_array.py
+++ b/tests/unit/modules/test_fusion_array.py
@@ -166,7 +166,7 @@ class TestArrayWorkflow:
     @patch(f"{current_module}.fusion_array.purefusion.ArraysApi.__new__")
     @patch(f"{current_module}.fusion_array.AnsibleModule")
     @patch(f"{current_module}.fusion_array.get_array")
-    def test_create_az_with_disp_name_successfully(
+    def test_create_array_with_disp_name_successfully(
         self, get_array, mock_ansible, mock_array_api, mock_op_api
     ):
         """


### PR DESCRIPTION
##### SUMMARY
Correct required parameters in all modules. Add possibility to update hardware types in Storage Service.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- _fusion_array_
- _fusion_hw_
- _fusion_pg_
- _fusion_pp_
- _fusion_sc_
- _fusion_ss_

##### ADDITIONAL INFORMATION
- Several modules in Fusion Ansible collection always required fields which were needed only for resource creation -> fixed
- Module _fusion_sc_ didn't require `storage_service` parameter, but would fail without it -> fixed
- Module _fusion_ss_ didn't allow updating hardware types even though this was supported by Pure Storage Fusion API -> fixed
- ModuleMock class didn't fail if `fail_json` or `fail_on_missing_params` was called, which might cause some test to pass even though they shouldn't -> fixed
- Integration tests and module examples were updated to reflect the changes.