### PR TITLE
Unify storage_classes key in fusion_info

### DIFF
--- a/changelogs/109_unify_storage_classes_key_in_fusion_info.yml
+++ b/changelogs/109_unify_storage_classes_key_in_fusion_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fusion_info - rename storageclass to storage_classes in response for consistency

--- a/plugins/modules/fusion_info.py
+++ b/plugins/modules/fusion_info.py
@@ -787,8 +787,8 @@ def generate_hardware_types_dict(module, fusion):
     return hardware_info
 
 
-@_api_permission_denied_handler("storageclass")
-def generate_storageclass_dict(module, fusion):
+@_api_permission_denied_handler("storage_classes")
+def generate_sc_dict(module, fusion):
     sc_info = {}
     ss_api_instance = purefusion.StorageServicesApi(fusion)
     sc_api_instance = purefusion.StorageClassesApi(fusion)
@@ -1078,7 +1078,7 @@ def main():
                 "The 'placements' subset is deprecated and will be removed in the version 1.7.0"
             )
     if "storage_classes" in subset or "all" in subset:
-        info["storageclass"] = generate_storageclass_dict(module, fusion)
+        info["storage_classes"] = generate_sc_dict(module, fusion)
     if "interfaces" in subset or "all" in subset:
         info["interfaces"] = generate_nics_dict(module, fusion)
     if "hosts" in subset or "all" in subset:

--- a/tests/integration/targets/fusion_sc/tasks/main.yml
+++ b/tests/integration/targets/fusion_sc/tasks/main.yml
@@ -47,7 +47,7 @@
   register: fusion_info
 - name: Validate the task
   ansible.builtin.assert:
-    that: "'foo_sc' in fusion_info['fusion_info']['storageclass']"
+    that: "'foo_sc' in fusion_info['fusion_info']['storage_classes']"
 
 - name: Delete storage class
   purestorage.fusion.fusion_sc:
@@ -69,7 +69,7 @@
   register: fusion_info
 - name: Validate the task
   ansible.builtin.assert:
-    that: "'foo_sc' not in fusion_info['fusion_info']['storageclass']"
+    that: "'foo_sc' not in fusion_info['fusion_info']['storage_classes']"
 
 
 # Teardown dependencies


### PR DESCRIPTION
##### SUMMARY

Rename `storageclass` to `storage_classes` in `fusion_info.py` to be the same as a key from `gather_subset` that user specifies.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

`fusion_info.py`

<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

Besides key, function `generate_storageclass_dict` renamed to be more consistent with other function names.