### PR TITLE
Unify hardware_types key in fusion_info

### DIFF
--- a/changelogs/112_unify_hardware_types_key_in_fusion_info.yml
+++ b/changelogs/112_unify_hardware_types_key_in_fusion_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fusion_info - rename hardware to hardware_types in response for consistency

--- a/plugins/modules/fusion_info.py
+++ b/plugins/modules/fusion_info.py
@@ -773,8 +773,8 @@ def generate_users_dict(module, fusion):
     return users_info
 
 
-@_api_permission_denied_handler("hardware")
-def generate_hardware_dict(module, fusion):
+@_api_permission_denied_handler("hardware_types")
+def generate_hardware_types_dict(module, fusion):
     hardware_info = {}
     api_instance = purefusion.HardwareTypesApi(fusion)
     hw_types = api_instance.list_hardware_types()
@@ -1057,7 +1057,7 @@ def main():
     if "minimum" in subset or "all" in subset:
         info["default"] = generate_default_dict(module, fusion)
     if "hardware_types" in subset or "all" in subset:
-        info["hardware"] = generate_hardware_dict(module, fusion)
+        info["hardware_types"] = generate_hardware_types_dict(module, fusion)
     if "users" in subset or "all" in subset:
         info["users"] = generate_users_dict(module, fusion)
     if "zones" in subset or "all" in subset:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Rename `hardware` to `hardware_types` in fusion_info.py to be the same as a key from `gather_subset` that user specifies.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

`fusion_info.py`
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Besides key, function `generate_hardware_dict` renamed to be more consistent with other function names.
