### PR TITLE
fusion_api_client: add display_name parameter

### DIFF
--- a/changelogs/123_add_display_name_to_fusion_api_client.yml
+++ b/changelogs/123_add_display_name_to_fusion_api_client.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fusion_api_client - add `display_name` parameter


### PR DESCRIPTION
##### SUMMARY
Add display_name parameter to the fusion_api_client module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- fusion_api_client

##### ADDITIONAL INFORMATION
fusion_api_client module was missing display_name parameter, it should have it to be in parity with Pure Storage Fusion API.