### PR TITLE
fusion_volume: remove rename example

### DIFF
--- a/plugins/modules/fusion_volume.py
+++ b/plugins/modules/fusion_volume.py
@@ -103,16 +103,6 @@ EXAMPLES = r"""
     issuer_id: key_name
     private_key_file: "az-admin-private-key.pem"
 
-- name: Rename volume named foo to bar
-  purestorage.fusion.fusion_volume:
-    name: foo
-    rename: bar
-    tenant: test
-    tenant_space: space_1
-    state: absent
-    issuer_id: key_name
-    private_key_file: "az-admin-private-key.pem"
-
 - name: Delete volume named foo
   purestorage.fusion.fusion_volume:
     name: foo


### PR DESCRIPTION
##### SUMMARY
Removing rename example from fusion volume module as rename operation has never been supported and doesn't work.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- fusion_volume

##### ADDITIONAL INFORMATION
This PR is duplicate of https://github.com/Pure-Storage-Ansible/Fusion-Collection/pull/122