### PR TITLE
Add access token parameter

### DIFF
--- a/changelogs/129_add_access_token.yml
+++ b/changelogs/129_add_access_token.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Fusion authentication - add 'access_token' module's parameter and 'FUSION_ACCESS_TOKEN' environment variable, as an alternative way of the authentication.

--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -35,10 +35,17 @@ options:
       - eg. pure1:apikey:dssf2331sd
       - Defaults to the set environment variable under FUSION_ISSUER_ID
     type: str
+  access_token:
+    description:
+      - Access token for Fusion Service
+      - Defaults to the set environment variable under FUSION_ACCESS_TOKEN
+    type: str
 notes:
   - This module requires the I(purefusion) Python library
   - You must set C(FUSION_ISSUER_ID) and C(FUSION_PRIVATE_KEY_FILE) environment variables
     if I(issuer_id) and I(private_key_file) arguments are not passed to the module directly
+  - If you want to use access token for authentication, you must use C(FUSION_ACCESS_TOKEN) environment variable
+    if I(access_token) argument is not passed to the module directly
 requirements:
   - python >= 3.8
   - purefusion

--- a/plugins/module_utils/fusion.py
+++ b/plugins/module_utils/fusion.py
@@ -106,7 +106,7 @@ def get_fusion(module):
     config = fusion.Configuration()
     config.host = environ.get(ENV_API_HOST, environ.get(ENV_HOST, config.host))
     config.token_endpoint = environ.get(ENV_TOKEN_ENDPOINT, config.token_endpoint)
-    
+
     if access_token is not None:
         config.access_token = access_token
     elif issuer_id is not None and key_file is not None:
@@ -121,52 +121,48 @@ def get_fusion(module):
         config.private_key_file = environ.get(ENV_PRIVATE_KEY_FILE)
     else:
         module.fail_json(
-            msg=f"You must set either {ENV_ISSUER_ID} and f{ENV_PRIVATE_KEY_FILE} or {ENV_ACCESS_TOKEN} environment variables. "
-            f"Or module arguments either {PARAM_ISSUER_ID} and f{PARAM_PRIVATE_KEY_FILE} or {ENV_ACCESS_TOKEN}"
+            msg=f"You must set either {ENV_ISSUER_ID} and {ENV_PRIVATE_KEY_FILE} or {ENV_ACCESS_TOKEN} environment variables. "
+            f"Or module arguments either {PARAM_ISSUER_ID} and {PARAM_PRIVATE_KEY_FILE} or {PARAM_ACCESS_TOKEN}"
         )
-        
+
     try:
         client = fusion.ApiClient(config)
         client.set_default_header("User-Agent", user_agent)
-    except Exception:
-            module.fail_json(msg="Unknown failure. Please contact Pure Support")
-        
-    try:
         api_instance = fusion.DefaultApi(client)
         api_instance.get_version()
     except Exception as err:
         module.fail_json(msg="Fusion authentication failed: {0}".format(err))
-        
+
     return client
 
 
 def fusion_argument_spec():
     """Return standard base dictionary used for the argument_spec argument in AnsibleModule"""
 
-    return dict(
-        issuer_id=dict(
-            no_log=True,
-            aliases=[PARAM_APP_ID],
-            deprecated_aliases=[
-                dict(
-                    name=PARAM_APP_ID,
-                    version=DEP_VER,
-                    collection_name="purefusion.fusion",
-                )
+    return {
+        PARAM_ISSUER_ID: {
+            "no_log": True,
+            "aliases": [PARAM_APP_ID],
+            "deprecated_aliases": [
+                {
+                    "name": PARAM_APP_ID,
+                    "version": DEP_VER,
+                    "collection_name": "purefusion.fusion",
+                }
             ],
-        ),
-        private_key_file=dict(
-            no_log=False,
-            aliases=[PARAM_KEY_FILE],
-            deprecated_aliases=[
-                dict(
-                    name=PARAM_KEY_FILE,
-                    version=DEP_VER,
-                    collection_name="purefusion.fusion",
-                )
+        },
+        PARAM_PRIVATE_KEY_FILE: {
+            "no_log": False,
+            "aliases": [PARAM_KEY_FILE],
+            "deprecated_aliases": [
+                {
+                    "name": PARAM_KEY_FILE,
+                    "version": DEP_VER,
+                    "collection_name": "purefusion.fusion",
+                }
             ],
-        ),
-        access_token=dict(
-            no_log=True,
-        ),
-    )
+        },
+        PARAM_ACCESS_TOKEN: {
+            "no_log": True,
+        },
+    }


### PR DESCRIPTION
##### SUMMARY
Add parameter and environment variable for access token. 
Access token can be use as an alternative way of the authentication. 

Module's parameter: `access_token`
Env var: `FUSION_ACCESS_TOKEN`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module_utils/fusion

