### PR TITLE
Implement functests for pg,pp and ra

### DIFF
--- a/changelogs/3289_functests_pp_pg_ra.yml
+++ b/changelogs/3289_functests_pp_pg_ra.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - fusion_ra - 'name' deprecated and aliased to 'role'
+  - fusion_pp - 'local_rpo' changed to accept same input as 'local_retention'
+  - fusion_pg - freshly created placement group is now moved to correct array

--- a/changelogs/3289_functests_pp_pg_ra.yml
+++ b/changelogs/3289_functests_pp_pg_ra.yml
@@ -1,4 +1,4 @@
-minor_changes:
+bugfixes:
   - fusion_ra - 'name' deprecated and aliased to 'role'
   - fusion_pp - 'local_rpo' changed to accept same input as 'local_retention'
   - fusion_pg - freshly created placement group is now moved to correct array

--- a/plugins/modules/fusion_pp.py
+++ b/plugins/modules/fusion_pp.py
@@ -129,9 +129,7 @@ def create_pp(module, fusion):
                 name=module.params["name"],
                 display_name=display_name,
                 objectives=[
-                    purefusion.RPO(
-                        type="RPO", rpo="PT" + str(module.params["local_rpo"]) + "M"
-                    ),
+                    purefusion.RPO(type="RPO", rpo="PT" + str(local_rpo) + "M"),
                     purefusion.Retention(
                         type="Retention", after="PT" + str(local_retention) + "M"
                     ),

--- a/tests/functional/test_fusion_api_client.py
+++ b/tests/functional/test_fusion_api_client.py
@@ -155,7 +155,7 @@ def test_api_client_create(m_im_api, current_clients):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_api_client.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed is True
 
     # check api was called correctly
     api_obj.list_api_clients.assert_called_once_with()
@@ -239,7 +239,7 @@ def test_api_client_present_not_changed(m_im_api, current_clients):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_api_client.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert exc.value.changed is False
 
     # check api was called correctly
     api_obj.list_api_clients.assert_called_once_with()
@@ -271,7 +271,7 @@ def test_api_client_absent_not_changed(m_im_api, current_clients):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_api_client.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert exc.value.changed is False
 
     # check api was called correctly
     api_obj.list_api_clients.assert_called_once_with()
@@ -306,7 +306,7 @@ def test_api_client_delete(m_im_api, current_clients):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_api_client.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed is True
 
     # check api was called correctly
     api_obj.list_api_clients.assert_called_once_with()

--- a/tests/functional/test_fusion_array.py
+++ b/tests/functional/test_fusion_array.py
@@ -363,7 +363,7 @@ def test_array_create(m_array_api, m_op_api, hw_type, main_m, unav_m, module_arg
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_array.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_array.assert_called_with(
@@ -456,7 +456,7 @@ def test_array_create_without_display_name(m_array_api, m_op_api, module_args):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_array.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_array.assert_called_with(
@@ -898,7 +898,7 @@ def test_array_update(m_array_api, m_op_api, module_args, current_array):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_array.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_array.assert_called_with(
@@ -1104,7 +1104,7 @@ def test_array_present_not_changed(m_array_api, m_op_api, module_args, current_a
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_array.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_array.assert_called_with(
@@ -1141,7 +1141,7 @@ def test_array_absent_not_changed(m_array_api, m_op_api, module_args):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_array.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_array.assert_called_with(
@@ -1178,7 +1178,7 @@ def test_array_delete(m_array_api, m_op_api, module_args, current_array):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_array.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_array.assert_called_once_with(

--- a/tests/functional/test_fusion_az.py
+++ b/tests/functional/test_fusion_az.py
@@ -138,7 +138,7 @@ def test_az_create(m_az_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_az.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     api_obj.get_region.get_availability_zone(
         availability_zone_name=module_args["name"],
@@ -185,7 +185,7 @@ def test_az_create_without_display_name(m_az_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_az.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     api_obj.get_region.get_availability_zone(
         availability_zone_name=module_args["name"],
@@ -392,7 +392,7 @@ def test_az_update(m_az_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_az.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     api_obj.get_region.get_availability_zone(
         availability_zone_name=module_args["name"],
@@ -475,7 +475,7 @@ def test_az_present_not_changed(m_az_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_az.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     api_obj.get_region.get_availability_zone(
         availability_zone_name=module_args["name"],
@@ -517,7 +517,7 @@ def test_az_absent_not_changed(m_az_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_az.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     api_obj.get_region.get_availability_zone(
         availability_zone_name=module_args["name"],
@@ -567,7 +567,7 @@ def test_az_delete(m_az_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_az.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     api_obj.get_region.get_availability_zone(
         availability_zone_name=module_args["name"],

--- a/tests/functional/test_fusion_pg.py
+++ b/tests/functional/test_fusion_pg.py
@@ -23,6 +23,7 @@ from ansible_collections.purestorage.fusion.tests.functional.utils import (
     exit_json,
     fail_json,
     set_module_args,
+    side_effects_with_exceptions,
 )
 from urllib3.exceptions import HTTPError
 
@@ -35,92 +36,140 @@ basic.AnsibleModule.exit_json = exit_json
 basic.AnsibleModule.fail_json = fail_json
 
 
+@pytest.fixture
+def module_args_present():
+    return {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+
+
+@pytest.fixture
+def module_args_absent():
+    return {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+
+
 @patch("fusion.OperationsApi")
 @patch("fusion.PlacementGroupsApi")
 @pytest.mark.parametrize(
-    "module_args",
+    ("module_args", "get_not_called"),
     [
         # 'name` is missing
-        {
-            "tenant": "tenant1",
-            "tenant_space": "tenant_space1",
-            "region": "region1",
-            "availability_zone": "availability_zone1",
-            "storage_service": "storage_service1",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "region": "region1",
+                "availability_zone": "availability_zone1",
+                "storage_service": "storage_service1",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            True,
+        ),
         # 'tenant` is missing
-        {
-            "name": "placement_group1",
-            "tenant_space": "tenant_space1",
-            "region": "region1",
-            "availability_zone": "availability_zone1",
-            "storage_service": "storage_service1",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "placement_group1",
+                "tenant_space": "tenant_space1",
+                "region": "region1",
+                "availability_zone": "availability_zone1",
+                "storage_service": "storage_service1",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            True,
+        ),
         # 'tenant space` is missing
-        {
-            "name": "placement_group1",
-            "tenant": "tenant1",
-            "region": "region1",
-            "availability_zone": "availability_zone1",
-            "storage_service": "storage_service1",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "placement_group1",
+                "tenant": "tenant1",
+                "region": "region1",
+                "availability_zone": "availability_zone1",
+                "storage_service": "storage_service1",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            True,
+        ),
         # 'region` is missing
-        {
-            "name": "placement_group1",
-            "tenant": "tenant1",
-            "tenant_space": "tenant_space1",
-            "availability_zone": "availability_zone1",
-            "storage_service": "storage_service1",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "placement_group1",
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "availability_zone": "availability_zone1",
+                "storage_service": "storage_service1",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            False,
+        ),
         # 'availability_zone` is missing
-        {
-            "name": "placement_group1",
-            "tenant": "tenant1",
-            "tenant_space": "tenant_space1",
-            "region": "region1",
-            "storage_service": "storage_service1",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "placement_group1",
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "region": "region1",
+                "storage_service": "storage_service1",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            False,
+        ),
         # 'storage_service` is missing
-        {
-            "name": "placement_group1",
-            "tenant": "tenant1",
-            "tenant_space": "tenant_space1",
-            "region": "region1",
-            "availability_zone": "availability_zone1",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "placement_group1",
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "region": "region1",
+                "availability_zone": "availability_zone1",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            False,
+        ),
         # 'state` is invalid
-        {
-            "name": "placement_group1",
-            "tenant": "tenant1",
-            "tenant_space": "tenant_space1",
-            "region": "region1",
-            "availability_zone": "availability_zone1",
-            "storage_service": "storage_service1",
-            "state": "past",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "placement_group1",
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "region": "region1",
+                "availability_zone": "availability_zone1",
+                "storage_service": "storage_service1",
+                "state": "past",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            False,
+        ),
     ],
 )
-def test_module_args_wrong(pg_api_init, op_api_init, module_args):
+def test_module_args_wrong(pg_api_init, op_api_init, module_args, get_not_called):
     set_module_args(module_args)
 
     pg_mock = MagicMock()
@@ -137,7 +186,9 @@ def test_module_args_wrong(pg_api_init, op_api_init, module_args):
     with pytest.raises(AnsibleFailJson):
         fusion_pg.main()
 
-    if pg_mock.get_placement_group.called:
+    if get_not_called:
+        pg_mock.get_placement_group.assert_not_called()
+    elif pg_mock.get_placement_group.called:
         pg_mock.get_placement_group.assert_called_with(
             tenant_name="tenant1",
             tenant_space_name="tenant_space1",
@@ -151,19 +202,9 @@ def test_module_args_wrong(pg_api_init, op_api_init, module_args):
 
 @patch("fusion.OperationsApi")
 @patch("fusion.PlacementGroupsApi")
-def test_pg_create_ok(pg_api_init, op_api_init):
-    module_args = {
-        "name": "placement_group1",
-        "display_name": "some_display_name",
-        "tenant": "tenant1",
-        "tenant_space": "tenant_space1",
-        "region": "region1",
-        "availability_zone": "availability_zone1",
-        "storage_service": "storage_service1",
-        "state": "present",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pg_create_ok(pg_api_init, op_api_init, module_args_present):
+    module_args = module_args_present
+    module_args["display_name"] = "some_display_name"
     set_module_args(module_args)
 
     pg_mock = MagicMock()
@@ -204,18 +245,10 @@ def test_pg_create_ok(pg_api_init, op_api_init):
 
 @patch("fusion.OperationsApi")
 @patch("fusion.PlacementGroupsApi")
-def test_pg_create_without_display_name_ok(pg_api_init, op_api_init):
-    module_args = {
-        "name": "placement_group1",
-        "tenant": "tenant1",
-        "tenant_space": "tenant_space1",
-        "region": "region1",
-        "availability_zone": "availability_zone1",
-        "storage_service": "storage_service1",
-        "state": "present",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pg_create_without_display_name_ok(
+    pg_api_init, op_api_init, module_args_present
+):
+    module_args = module_args_present
     set_module_args(module_args)
 
     pg_mock = MagicMock()
@@ -264,20 +297,9 @@ def test_pg_create_without_display_name_ok(pg_api_init, op_api_init):
     ],
 )
 def test_pg_create_exception(
-    pg_api_init, op_api_init, raised_exception, expected_exception
+    pg_api_init, op_api_init, raised_exception, expected_exception, module_args_present
 ):
-    module_args = {
-        "name": "placement_group1",
-        "tenant": "tenant1",
-        "tenant_space": "tenant_space1",
-        "region": "region1",
-        "availability_zone": "availability_zone1",
-        "storage_service": "storage_service1",
-        "state": "present",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
-    set_module_args(module_args)
+    set_module_args(module_args_present)
 
     pg_mock = MagicMock()
     pg_mock.get_placement_group = MagicMock(side_effect=purefusion.rest.ApiException)
@@ -316,18 +338,8 @@ def test_pg_create_exception(
 
 @patch("fusion.OperationsApi")
 @patch("fusion.PlacementGroupsApi")
-def test_pg_create_op_fails(pg_api_init, op_api_init):
-    module_args = {
-        "name": "placement_group1",
-        "tenant": "tenant1",
-        "tenant_space": "tenant_space1",
-        "region": "region1",
-        "availability_zone": "availability_zone1",
-        "storage_service": "storage_service1",
-        "state": "present",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pg_create_op_fails(pg_api_init, op_api_init, module_args_present):
+    module_args = module_args_present
     set_module_args(module_args)
 
     pg_mock = MagicMock()
@@ -384,7 +396,7 @@ def test_pg_create_triggers_update_ok(pg_api_init, op_api_init):
     set_module_args(module_args)
 
     get_placement_group_effects = [
-        None,
+        purefusion.rest.ApiException(),
         purefusion.PlacementGroup(
             id="placement_group1_id",
             name="placement_group1",
@@ -422,16 +434,10 @@ def test_pg_create_triggers_update_ok(pg_api_init, op_api_init):
         ),
     ]
 
-    def get_placement_group_effect(
-        tenant_name, tenant_space_name, placement_group_name
-    ):
-        i = get_placement_group_effects.pop(0)
-        if i is None:
-            raise purefusion.rest.ApiException()
-        return i
-
     pg_mock = MagicMock()
-    pg_mock.get_placement_group = MagicMock(side_effect=get_placement_group_effect)
+    pg_mock.get_placement_group = MagicMock(
+        side_effect=side_effects_with_exceptions(get_placement_group_effects)
+    )
     pg_mock.create_placement_group = MagicMock(return_value=OperationMock("op1"))
     pg_mock.update_placement_group = MagicMock(return_value=OperationMock("op2"))
     pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
@@ -509,7 +515,7 @@ def test_pg_create_triggers_update_exception(
     set_module_args(module_args)
 
     get_placement_group_effects = [
-        None,
+        purefusion.rest.ApiException(),
         purefusion.PlacementGroup(
             id="placement_group1_id",
             name="placement_group1",
@@ -547,16 +553,10 @@ def test_pg_create_triggers_update_exception(
         ),
     ]
 
-    def get_placement_group_effect(
-        tenant_name, tenant_space_name, placement_group_name
-    ):
-        i = get_placement_group_effects.pop(0)
-        if i is None:
-            raise purefusion.rest.ApiException()
-        return i
-
     pg_mock = MagicMock()
-    pg_mock.get_placement_group = MagicMock(side_effect=get_placement_group_effect)
+    pg_mock.get_placement_group = MagicMock(
+        side_effect=side_effects_with_exceptions(get_placement_group_effects)
+    )
     pg_mock.create_placement_group = MagicMock(return_value=OperationMock("op1"))
     pg_mock.update_placement_group = MagicMock(side_effect=raised_exception)
     pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
@@ -624,7 +624,7 @@ def test_pg_create_triggers_update_op_fails(pg_api_init, op_api_init):
     set_module_args(module_args)
 
     get_placement_group_effects = [
-        None,
+        purefusion.rest.ApiException(),
         purefusion.PlacementGroup(
             id="placement_group1_id",
             name="placement_group1",
@@ -662,16 +662,10 @@ def test_pg_create_triggers_update_op_fails(pg_api_init, op_api_init):
         ),
     ]
 
-    def get_placement_group_effect(
-        tenant_name, tenant_space_name, placement_group_name
-    ):
-        i = get_placement_group_effects.pop(0)
-        if i is None:
-            raise purefusion.rest.ApiException()
-        return i
-
     pg_mock = MagicMock()
-    pg_mock.get_placement_group = MagicMock(side_effect=get_placement_group_effect)
+    pg_mock.get_placement_group = MagicMock(
+        side_effect=side_effects_with_exceptions(get_placement_group_effects)
+    )
     pg_mock.create_placement_group = MagicMock(return_value=OperationMock("op1"))
     pg_mock.update_placement_group = MagicMock(return_value=OperationMock("op2"))
     pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
@@ -1003,14 +997,6 @@ def test_pg_update_exception(
         ),
     ]
 
-    def test_update_return_value(
-        patch, tenant_name, tenant_space_name, placement_group_name
-    ):
-        idx = patches.index(patch)
-        if idx == failing_patch:
-            raise raised_exception()
-        return OperationMock(id="op{0}".format(idx))
-
     pg_mock = MagicMock()
     pg_mock.get_placement_group = MagicMock(
         return_value=purefusion.PlacementGroup(
@@ -1050,7 +1036,9 @@ def test_pg_update_exception(
         )
     )
     pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
-    pg_mock.update_placement_group = MagicMock(side_effect=test_update_return_value)
+    pg_mock.update_placement_group = MagicMock(
+        side_effect=throw_on_specific_patch(patches, failing_patch, raised_exception, 0)
+    )
     pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
     pg_api_init.return_value = pg_mock
 
@@ -1109,14 +1097,6 @@ def test_pg_update_exception(
         ),
     ]
 
-    def test_update_return_value(
-        patch, tenant_name, tenant_space_name, placement_group_name
-    ):
-        idx = patches.index(patch)
-        if idx == failing_patch:
-            raise raised_exception()
-        return OperationMock(id="op{0}".format(idx))
-
     pg_mock = MagicMock()
     pg_mock.get_placement_group = MagicMock(
         return_value=purefusion.PlacementGroup(
@@ -1156,7 +1136,9 @@ def test_pg_update_exception(
         )
     )
     pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
-    pg_mock.update_placement_group = MagicMock(side_effect=test_update_return_value)
+    pg_mock.update_placement_group = MagicMock(
+        side_effect=throw_on_specific_patch(patches, failing_patch, raised_exception, 0)
+    )
     pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
     pg_api_init.return_value = pg_mock
 
@@ -1276,15 +1258,8 @@ def test_pg_update_op_fails(pg_api_init, op_api_init, failing_patch):
 
 @patch("fusion.OperationsApi")
 @patch("fusion.PlacementGroupsApi")
-def test_pg_delete_ok(pg_api_init, op_api_init):
-    module_args = {
-        "name": "placement_group1",
-        "tenant": "tenant1",
-        "tenant_space": "tenant_space1",
-        "state": "absent",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pg_delete_ok(pg_api_init, op_api_init, module_args_absent):
+    module_args = module_args_absent
     set_module_args(module_args)
 
     pg_mock = MagicMock()
@@ -1365,16 +1340,9 @@ def test_pg_delete_ok(pg_api_init, op_api_init):
     ],
 )
 def test_pg_delete_exception(
-    pg_api_init, op_api_init, raised_exception, expected_exception
+    pg_api_init, op_api_init, raised_exception, expected_exception, module_args_absent
 ):
-    module_args = {
-        "name": "placement_group1",
-        "tenant": "tenant1",
-        "tenant_space": "tenant_space1",
-        "state": "absent",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+    module_args = module_args_absent
     set_module_args(module_args)
 
     pg_mock = MagicMock()
@@ -1444,15 +1412,8 @@ def test_pg_delete_exception(
 
 @patch("fusion.OperationsApi")
 @patch("fusion.PlacementGroupsApi")
-def test_pg_delete_op_fails(pg_api_init, op_api_init):
-    module_args = {
-        "name": "placement_group1",
-        "tenant": "tenant1",
-        "tenant_space": "tenant_space1",
-        "state": "absent",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pg_delete_op_fails(pg_api_init, op_api_init, module_args_absent):
+    module_args = module_args_absent
     set_module_args(module_args)
 
     pg_mock = MagicMock()
@@ -1524,18 +1485,8 @@ def test_pg_delete_op_fails(pg_api_init, op_api_init):
 
 @patch("fusion.OperationsApi")
 @patch("fusion.PlacementGroupsApi")
-def test_pg_present_not_changed(pg_api_init, op_api_init):
-    module_args = {
-        "name": "placement_group1",
-        "tenant": "tenant1",
-        "tenant_space": "tenant_space1",
-        "region": "region1",
-        "availability_zone": "availability_zone1",
-        "storage_service": "storage_service1",
-        "state": "present",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pg_present_not_changed(pg_api_init, op_api_init, module_args_present):
+    module_args = module_args_present
     set_module_args(module_args)
 
     pg_mock = MagicMock()
@@ -1602,15 +1553,8 @@ def test_pg_present_not_changed(pg_api_init, op_api_init):
 
 @patch("fusion.OperationsApi")
 @patch("fusion.PlacementGroupsApi")
-def test_pg_absent_not_changed(pg_api_init, op_api_init):
-    module_args = {
-        "name": "placement_group1",
-        "tenant": "tenant1",
-        "tenant_space": "tenant_space1",
-        "state": "absent",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pg_absent_not_changed(pg_api_init, op_api_init, module_args_absent):
+    module_args = module_args_absent
     set_module_args(module_args)
 
     pg_mock = MagicMock()
@@ -1637,3 +1581,15 @@ def test_pg_absent_not_changed(pg_api_init, op_api_init):
     pg_mock.update_placement_group.assert_not_called()
     pg_mock.delete_placement_group.assert_not_called()
     op_mock.get_operation.assert_not_called()
+
+
+def throw_on_specific_patch(patches, failing_patch_idx, raised_exception, op_offset):
+    patches = patches.copy()
+
+    def _update_side_effect(patch, **kwargs):
+        idx = patches.index(patch)
+        if idx == failing_patch_idx:
+            raise raised_exception()
+        return OperationMock(id="op{0}".format(op_offset + idx))
+
+    return _update_side_effect

--- a/tests/functional/test_fusion_pg.py
+++ b/tests/functional/test_fusion_pg.py
@@ -1,0 +1,1639 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2023 Pure Storage, Inc.
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from unittest.mock import MagicMock, patch, call
+
+import fusion as purefusion
+import pytest
+from ansible.module_utils import basic
+from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
+    OperationException,
+)
+from ansible_collections.purestorage.fusion.plugins.modules import fusion_pg
+from ansible_collections.purestorage.fusion.tests.functional.utils import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    OperationMock,
+    exit_json,
+    fail_json,
+    set_module_args,
+)
+from urllib3.exceptions import HTTPError
+
+# GLOBAL MOCKS
+fusion_pg.setup_fusion = MagicMock(return_value=purefusion.api_client.ApiClient())
+purefusion.api_client.ApiClient.call_api = MagicMock(
+    side_effect=Exception("API call not mocked!")
+)
+basic.AnsibleModule.exit_json = exit_json
+basic.AnsibleModule.fail_json = fail_json
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+@pytest.mark.parametrize(
+    "module_args",
+    [
+        # 'name` is missing
+        {
+            "tenant": "tenant1",
+            "tenant_space": "tenant_space1",
+            "region": "region1",
+            "availability_zone": "availability_zone1",
+            "storage_service": "storage_service1",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'tenant` is missing
+        {
+            "name": "placement_group1",
+            "tenant_space": "tenant_space1",
+            "region": "region1",
+            "availability_zone": "availability_zone1",
+            "storage_service": "storage_service1",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'tenant space` is missing
+        {
+            "name": "placement_group1",
+            "tenant": "tenant1",
+            "region": "region1",
+            "availability_zone": "availability_zone1",
+            "storage_service": "storage_service1",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'region` is missing
+        {
+            "name": "placement_group1",
+            "tenant": "tenant1",
+            "tenant_space": "tenant_space1",
+            "availability_zone": "availability_zone1",
+            "storage_service": "storage_service1",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'availability_zone` is missing
+        {
+            "name": "placement_group1",
+            "tenant": "tenant1",
+            "tenant_space": "tenant_space1",
+            "region": "region1",
+            "storage_service": "storage_service1",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'storage_service` is missing
+        {
+            "name": "placement_group1",
+            "tenant": "tenant1",
+            "tenant_space": "tenant_space1",
+            "region": "region1",
+            "availability_zone": "availability_zone1",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'state` is invalid
+        {
+            "name": "placement_group1",
+            "tenant": "tenant1",
+            "tenant_space": "tenant_space1",
+            "region": "region1",
+            "availability_zone": "availability_zone1",
+            "storage_service": "storage_service1",
+            "state": "past",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+    ],
+)
+def test_module_args_wrong(pg_api_init, op_api_init, module_args):
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(side_effect=purefusion.rest.ApiException)
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=purefusion.rest.ApiException)
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleFailJson):
+        fusion_pg.main()
+
+    if pg_mock.get_placement_group.called:
+        pg_mock.get_placement_group.assert_called_with(
+            tenant_name="tenant1",
+            tenant_space_name="tenant_space1",
+            placement_group_name="placement_group1",
+        )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.update_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+def test_pg_create_ok(pg_api_init, op_api_init):
+    module_args = {
+        "name": "placement_group1",
+        "display_name": "some_display_name",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(side_effect=purefusion.rest.ApiException)
+    pg_mock.create_placement_group = MagicMock(return_value=OperationMock("op1"))
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=True))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pg.main()
+    assert excinfo.value.changed
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_called_with(
+        purefusion.PlacementGroupPost(
+            name="placement_group1",
+            display_name="some_display_name",
+            availability_zone="availability_zone1",
+            region="region1",
+            storage_service="storage_service1",
+        ),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+    )
+    pg_mock.update_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+def test_pg_create_without_display_name_ok(pg_api_init, op_api_init):
+    module_args = {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(side_effect=purefusion.rest.ApiException)
+    pg_mock.create_placement_group = MagicMock(return_value=OperationMock("op1"))
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=True))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pg.main()
+    assert excinfo.value.changed
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_called_with(
+        purefusion.PlacementGroupPost(
+            name="placement_group1",
+            display_name="placement_group1",
+            availability_zone="availability_zone1",
+            region="region1",
+            storage_service="storage_service1",
+        ),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+    )
+    pg_mock.update_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+@pytest.mark.parametrize(
+    ("raised_exception", "expected_exception"),
+    [
+        (purefusion.rest.ApiException, purefusion.rest.ApiException),
+        (HTTPError, HTTPError),
+    ],
+)
+def test_pg_create_exception(
+    pg_api_init, op_api_init, raised_exception, expected_exception
+):
+    module_args = {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(side_effect=purefusion.rest.ApiException)
+    pg_mock.create_placement_group = MagicMock(side_effect=raised_exception)
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(expected_exception):
+        fusion_pg.main()
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_called_with(
+        purefusion.PlacementGroupPost(
+            name="placement_group1",
+            display_name="placement_group1",
+            availability_zone="availability_zone1",
+            region="region1",
+            storage_service="storage_service1",
+        ),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+    )
+    pg_mock.delete_placement_group.assert_not_called()
+    pg_mock.update_placement_group.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+def test_pg_create_op_fails(pg_api_init, op_api_init):
+    module_args = {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(side_effect=purefusion.rest.ApiException)
+    pg_mock.create_placement_group = MagicMock(return_value=OperationMock(id="op1"))
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=False))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(OperationException):
+        fusion_pg.main()
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_called_with(
+        purefusion.PlacementGroupPost(
+            name="placement_group1",
+            display_name="placement_group1",
+            availability_zone="availability_zone1",
+            region="region1",
+            storage_service="storage_service1",
+        ),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+    )
+    pg_mock.update_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+def test_pg_create_triggers_update_ok(pg_api_init, op_api_init):
+    module_args = {
+        "name": "placement_group1",
+        "display_name": "some_display_name",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "array": "array2",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    get_placement_group_effects = [
+        None,
+        purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="some_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        ),
+    ]
+
+    def get_placement_group_effect(
+        tenant_name, tenant_space_name, placement_group_name
+    ):
+        i = get_placement_group_effects.pop(0)
+        if i is None:
+            raise purefusion.rest.ApiException()
+        return i
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(side_effect=get_placement_group_effect)
+    pg_mock.create_placement_group = MagicMock(return_value=OperationMock("op1"))
+    pg_mock.update_placement_group = MagicMock(return_value=OperationMock("op2"))
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=True))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pg.main()
+    assert excinfo.value.changed
+
+    pg_mock.get_placement_group.assert_has_calls(
+        [
+            call(
+                tenant_name="tenant1",
+                tenant_space_name="tenant_space1",
+                placement_group_name="placement_group1",
+            ),
+            call(
+                tenant_name="tenant1",
+                tenant_space_name="tenant_space1",
+                placement_group_name="placement_group1",
+            ),
+        ],
+        any_order=True,
+    )
+    pg_mock.create_placement_group.assert_called_with(
+        purefusion.PlacementGroupPost(
+            name="placement_group1",
+            display_name="some_display_name",
+            availability_zone="availability_zone1",
+            region="region1",
+            storage_service="storage_service1",
+        ),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+    )
+    pg_mock.update_placement_group.assert_called_with(
+        purefusion.PlacementGroupPatch(array=purefusion.NullableString(value="array2")),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_has_calls([call("op1"), call("op2")], any_order=True)
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+@pytest.mark.parametrize(
+    ("raised_exception", "expected_exception"),
+    [
+        (purefusion.rest.ApiException, purefusion.rest.ApiException),
+        (HTTPError, HTTPError),
+    ],
+)
+def test_pg_create_triggers_update_exception(
+    pg_api_init, op_api_init, raised_exception, expected_exception
+):
+    module_args = {
+        "name": "placement_group1",
+        "display_name": "some_display_name",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "array": "array2",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    get_placement_group_effects = [
+        None,
+        purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="some_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        ),
+    ]
+
+    def get_placement_group_effect(
+        tenant_name, tenant_space_name, placement_group_name
+    ):
+        i = get_placement_group_effects.pop(0)
+        if i is None:
+            raise purefusion.rest.ApiException()
+        return i
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(side_effect=get_placement_group_effect)
+    pg_mock.create_placement_group = MagicMock(return_value=OperationMock("op1"))
+    pg_mock.update_placement_group = MagicMock(side_effect=raised_exception)
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=True))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(expected_exception):
+        fusion_pg.main()
+
+    pg_mock.get_placement_group.assert_has_calls(
+        [
+            call(
+                tenant_name="tenant1",
+                tenant_space_name="tenant_space1",
+                placement_group_name="placement_group1",
+            ),
+            call(
+                tenant_name="tenant1",
+                tenant_space_name="tenant_space1",
+                placement_group_name="placement_group1",
+            ),
+        ],
+        any_order=True,
+    )
+    pg_mock.create_placement_group.assert_called_with(
+        purefusion.PlacementGroupPost(
+            name="placement_group1",
+            display_name="some_display_name",
+            availability_zone="availability_zone1",
+            region="region1",
+            storage_service="storage_service1",
+        ),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+    )
+    pg_mock.update_placement_group.assert_called_with(
+        purefusion.PlacementGroupPatch(array=purefusion.NullableString(value="array2")),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+def test_pg_create_triggers_update_op_fails(pg_api_init, op_api_init):
+    module_args = {
+        "name": "placement_group1",
+        "display_name": "some_display_name",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "array": "array2",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    get_placement_group_effects = [
+        None,
+        purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="some_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        ),
+    ]
+
+    def get_placement_group_effect(
+        tenant_name, tenant_space_name, placement_group_name
+    ):
+        i = get_placement_group_effects.pop(0)
+        if i is None:
+            raise purefusion.rest.ApiException()
+        return i
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(side_effect=get_placement_group_effect)
+    pg_mock.create_placement_group = MagicMock(return_value=OperationMock("op1"))
+    pg_mock.update_placement_group = MagicMock(return_value=OperationMock("op2"))
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        side_effect=[
+            OperationMock("op1", success=True),
+            OperationMock("op2", success=False),
+        ]
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(OperationException):
+        fusion_pg.main()
+
+    pg_mock.get_placement_group.assert_has_calls(
+        [
+            call(
+                tenant_name="tenant1",
+                tenant_space_name="tenant_space1",
+                placement_group_name="placement_group1",
+            ),
+            call(
+                tenant_name="tenant1",
+                tenant_space_name="tenant_space1",
+                placement_group_name="placement_group1",
+            ),
+        ],
+        any_order=True,
+    )
+    pg_mock.create_placement_group.assert_called_with(
+        purefusion.PlacementGroupPost(
+            name="placement_group1",
+            display_name="some_display_name",
+            availability_zone="availability_zone1",
+            region="region1",
+            storage_service="storage_service1",
+        ),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+    )
+    pg_mock.update_placement_group.assert_called_with(
+        purefusion.PlacementGroupPatch(array=purefusion.NullableString(value="array2")),
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_has_calls([call("op1"), call("op2")])
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        # patch 'display_name`
+        {
+            "current_state": purefusion.PlacementGroup(
+                id="placement_group1_id",
+                name="placement_group1",
+                display_name="placement_group1_display_name",
+                self_link="test_self_link",
+                tenant=purefusion.TenantRef(
+                    id="tenant1_id",
+                    name="tenant1",
+                    kind="Tenant",
+                    self_link="some_self_link",
+                ),
+                tenant_space=purefusion.TenantSpaceRef(
+                    id="tenant_space1_id",
+                    name="tenant_space1",
+                    kind="TenantSpace",
+                    self_link="some_self_link",
+                ),
+                availability_zone=purefusion.AvailabilityZoneRef(
+                    id="availability_zone1_id",
+                    name="availability_zone1",
+                    kind="AvailabilityZone",
+                    self_link="some_self_link",
+                ),
+                placement_engine="heuristics",
+                protocols=[],
+                storage_service=purefusion.StorageServiceRef(
+                    id="storage_service1_id",
+                    name="storage_service",
+                    kind="StorageService",
+                    self_link="some_self_link",
+                ),
+                array=purefusion.ArrayRef(
+                    id="array1_id",
+                    name="array1",
+                    kind="Array",
+                    self_link="some_self_link",
+                ),
+            ),
+            "module_args": {
+                "name": "placement_group1",
+                "display_name": "different_display_name",
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "region": "region1",
+                "availability_zone": "availability_zone1",
+                "storage_service": "storage_service1",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            "patches": [
+                purefusion.PlacementGroupPatch(
+                    display_name=purefusion.NullableString(
+                        value="different_display_name"
+                    ),
+                ),
+            ],
+        },
+        # patch 'array`
+        {
+            "current_state": purefusion.PlacementGroup(
+                id="placement_group1_id",
+                name="placement_group1",
+                display_name="placement_group1",
+                self_link="test_self_link",
+                tenant=purefusion.TenantRef(
+                    id="tenant1_id",
+                    name="tenant1",
+                    kind="Tenant",
+                    self_link="some_self_link",
+                ),
+                tenant_space=purefusion.TenantSpaceRef(
+                    id="tenant_space1_id",
+                    name="tenant_space1",
+                    kind="TenantSpace",
+                    self_link="some_self_link",
+                ),
+                availability_zone=purefusion.AvailabilityZoneRef(
+                    id="availability_zone1_id",
+                    name="availability_zone1",
+                    kind="AvailabilityZone",
+                    self_link="some_self_link",
+                ),
+                placement_engine="heuristics",
+                protocols=[],
+                storage_service=purefusion.StorageServiceRef(
+                    id="storage_service1_id",
+                    name="storage_service",
+                    kind="StorageService",
+                    self_link="some_self_link",
+                ),
+                array=purefusion.ArrayRef(
+                    id="array1_id",
+                    name="array1",
+                    kind="Array",
+                    self_link="some_self_link",
+                ),
+            ),
+            "module_args": {
+                "name": "placement_group1",
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "region": "region1",
+                "availability_zone": "availability_zone1",
+                "storage_service": "storage_service1",
+                "array": "array2",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            "patches": [
+                purefusion.PlacementGroupPatch(
+                    array=purefusion.NullableString(value="array2"),
+                ),
+            ],
+        },
+        # patch all
+        {
+            "current_state": purefusion.PlacementGroup(
+                id="placement_group1_id",
+                name="placement_group1",
+                display_name="placement_group1_display_name",
+                self_link="test_self_link",
+                tenant=purefusion.TenantRef(
+                    id="tenant1_id",
+                    name="tenant1",
+                    kind="Tenant",
+                    self_link="some_self_link",
+                ),
+                tenant_space=purefusion.TenantSpaceRef(
+                    id="tenant_space1_id",
+                    name="tenant_space1",
+                    kind="TenantSpace",
+                    self_link="some_self_link",
+                ),
+                availability_zone=purefusion.AvailabilityZoneRef(
+                    id="availability_zone1_id",
+                    name="availability_zone1",
+                    kind="AvailabilityZone",
+                    self_link="some_self_link",
+                ),
+                placement_engine="heuristics",
+                protocols=[],
+                storage_service=purefusion.StorageServiceRef(
+                    id="storage_service1_id",
+                    name="storage_service",
+                    kind="StorageService",
+                    self_link="some_self_link",
+                ),
+                array=purefusion.ArrayRef(
+                    id="array1_id",
+                    name="array1",
+                    kind="Array",
+                    self_link="some_self_link",
+                ),
+            ),
+            "module_args": {
+                "name": "placement_group1",
+                "display_name": "different_display_name",
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "region": "region1",
+                "availability_zone": "availability_zone1",
+                "storage_service": "storage_service1",
+                "array": "array2",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            "patches": [
+                purefusion.PlacementGroupPatch(
+                    display_name=purefusion.NullableString(
+                        value="different_display_name"
+                    ),
+                ),
+                purefusion.PlacementGroupPatch(
+                    array=purefusion.NullableString(value="array2"),
+                ),
+            ],
+        },
+    ],
+)
+def test_pg_update_ok(pg_api_init, op_api_init, test_case):
+    module_args = test_case["module_args"]
+    set_module_args(module_args)
+
+    get_operation_calls = [
+        call("op{0}".format(i)) for i in range(len(test_case["patches"]))
+    ]
+    update_placement_group_return_vals = [
+        OperationMock(id="op{0}".format(i)) for i in range(len(test_case["patches"]))
+    ]
+    update_placement_group_calls = [
+        call(
+            p,
+            tenant_name="tenant1",
+            tenant_space_name="tenant_space1",
+            placement_group_name="placement_group1",
+        )
+        for p in test_case["patches"]
+    ]
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(return_value=test_case["current_state"])
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(
+        side_effect=update_placement_group_return_vals
+    )
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        side_effect=lambda op_id: OperationMock(id=op_id, success=True)
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pg.main()
+    assert excinfo.value.changed
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.update_placement_group.assert_has_calls(
+        update_placement_group_calls, any_order=True
+    )
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_has_calls(get_operation_calls, any_order=True)
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+@pytest.mark.parametrize("failing_patch", [0, 1])
+@pytest.mark.parametrize(
+    ("raised_exception", "expected_exception"),
+    [
+        (purefusion.rest.ApiException, purefusion.rest.ApiException),
+        (HTTPError, HTTPError),
+    ],
+)
+def test_pg_update_exception(
+    pg_api_init, op_api_init, failing_patch, raised_exception, expected_exception
+):
+    module_args = {
+        "name": "placement_group1",
+        "display_name": "different_display_name",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "array": "array2",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    patches = [
+        purefusion.PlacementGroupPatch(
+            display_name=purefusion.NullableString(value="different_display_name"),
+        ),
+        purefusion.PlacementGroupPatch(
+            array=purefusion.NullableString(value="array2"),
+        ),
+    ]
+
+    def test_update_return_value(
+        patch, tenant_name, tenant_space_name, placement_group_name
+    ):
+        idx = patches.index(patch)
+        if idx == failing_patch:
+            raise raised_exception()
+        return OperationMock(id="op{0}".format(idx))
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(
+        return_value=purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="placement_group1_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        )
+    )
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(side_effect=test_update_return_value)
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        side_effect=lambda op_id: OperationMock(id=op_id, success=True)
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(expected_exception):
+        fusion_pg.main()
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+@pytest.mark.parametrize("failing_patch", [0, 1])
+@pytest.mark.parametrize(
+    ("raised_exception", "expected_exception"),
+    [
+        (purefusion.rest.ApiException, purefusion.rest.ApiException),
+        (HTTPError, HTTPError),
+    ],
+)
+def test_pg_update_exception(
+    pg_api_init, op_api_init, failing_patch, raised_exception, expected_exception
+):
+    module_args = {
+        "name": "placement_group1",
+        "display_name": "different_display_name",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "array": "array2",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    patches = [
+        purefusion.PlacementGroupPatch(
+            display_name=purefusion.NullableString(value="different_display_name"),
+        ),
+        purefusion.PlacementGroupPatch(
+            array=purefusion.NullableString(value="array2"),
+        ),
+    ]
+
+    def test_update_return_value(
+        patch, tenant_name, tenant_space_name, placement_group_name
+    ):
+        idx = patches.index(patch)
+        if idx == failing_patch:
+            raise raised_exception()
+        return OperationMock(id="op{0}".format(idx))
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(
+        return_value=purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="placement_group1_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        )
+    )
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(side_effect=test_update_return_value)
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        side_effect=lambda op_id: OperationMock(id=op_id, success=True)
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(expected_exception) as excinfo:
+        fusion_pg.main()
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+@pytest.mark.parametrize("failing_patch", [0, 1])
+def test_pg_update_op_fails(pg_api_init, op_api_init, failing_patch):
+    module_args = {
+        "name": "placement_group1",
+        "display_name": "different_display_name",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "array": "array2",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    patches = [
+        purefusion.PlacementGroupPatch(
+            display_name=purefusion.NullableString(value="different_display_name"),
+        ),
+        purefusion.PlacementGroupPatch(
+            array=purefusion.NullableString(value="array2"),
+        ),
+    ]
+    ops = ["op0", "op1"]
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(
+        return_value=purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="placement_group1_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        )
+    )
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(
+        side_effect=lambda patch, tenant_name, tenant_space_name, placement_group_name: OperationMock(
+            id="op{0}".format(patches.index(patch))
+        )
+    )
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        side_effect=lambda id: OperationMock(
+            id=id, success=ops.index(id) != failing_patch
+        )
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(OperationException):
+        fusion_pg.main()
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+def test_pg_delete_ok(pg_api_init, op_api_init):
+    module_args = {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(
+        return_value=purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="placement_group1_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        )
+    )
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(return_value=OperationMock(id="op1"))
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        return_value=OperationMock(id="op1", success=True)
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pg.main()
+    assert excinfo.value.changed
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.update_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+@pytest.mark.parametrize(
+    ("raised_exception", "expected_exception"),
+    [
+        (purefusion.rest.ApiException, purefusion.rest.ApiException),
+        (HTTPError, HTTPError),
+    ],
+)
+def test_pg_delete_exception(
+    pg_api_init, op_api_init, raised_exception, expected_exception
+):
+    module_args = {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(
+        return_value=purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="placement_group1_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        )
+    )
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(side_effect=raised_exception)
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(expected_exception):
+        fusion_pg.main()
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.update_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+def test_pg_delete_op_fails(pg_api_init, op_api_init):
+    module_args = {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(
+        return_value=purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="placement_group1_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        )
+    )
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(return_value=OperationMock(id="op1"))
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        return_value=OperationMock(id="op1", success=False)
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(OperationException):
+        fusion_pg.main()
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.update_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+def test_pg_present_not_changed(pg_api_init, op_api_init):
+    module_args = {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "region": "region1",
+        "availability_zone": "availability_zone1",
+        "storage_service": "storage_service1",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(
+        return_value=purefusion.PlacementGroup(
+            id="placement_group1_id",
+            name="placement_group1",
+            display_name="placement_group1_display_name",
+            self_link="test_self_link",
+            tenant=purefusion.TenantRef(
+                id="tenant1_id",
+                name="tenant1",
+                kind="Tenant",
+                self_link="some_self_link",
+            ),
+            tenant_space=purefusion.TenantSpaceRef(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                kind="TenantSpace",
+                self_link="some_self_link",
+            ),
+            availability_zone=purefusion.AvailabilityZoneRef(
+                id="availability_zone1_id",
+                name="availability_zone1",
+                kind="AvailabilityZone",
+                self_link="some_self_link",
+            ),
+            placement_engine="heuristics",
+            protocols=[],
+            storage_service=purefusion.StorageServiceRef(
+                id="storage_service1_id",
+                name="storage_service",
+                kind="StorageService",
+                self_link="some_self_link",
+            ),
+            array=purefusion.ArrayRef(
+                id="array1_id", name="array1", kind="Array", self_link="some_self_link"
+            ),
+        )
+    )
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pg.main()
+    assert not excinfo.value.changed
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.update_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.PlacementGroupsApi")
+def test_pg_absent_not_changed(pg_api_init, op_api_init):
+    module_args = {
+        "name": "placement_group1",
+        "tenant": "tenant1",
+        "tenant_space": "tenant_space1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pg_mock = MagicMock()
+    pg_mock.get_placement_group = MagicMock(side_effect=purefusion.rest.ApiException)
+    pg_mock.create_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.update_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_mock.delete_placement_group = MagicMock(side_effect=NotImplementedError())
+    pg_api_init.return_value = pg_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pg.main()
+    assert not excinfo.value.changed
+
+    pg_mock.get_placement_group.assert_called_with(
+        tenant_name="tenant1",
+        tenant_space_name="tenant_space1",
+        placement_group_name="placement_group1",
+    )
+    pg_mock.create_placement_group.assert_not_called()
+    pg_mock.update_placement_group.assert_not_called()
+    pg_mock.delete_placement_group.assert_not_called()
+    op_mock.get_operation.assert_not_called()

--- a/tests/functional/test_fusion_pp.py
+++ b/tests/functional/test_fusion_pp.py
@@ -162,16 +162,10 @@ def test_module_args_wrong(pp_api_init, op_api_init, module_args, get_not_called
 
 @patch("fusion.OperationsApi")
 @patch("fusion.ProtectionPoliciesApi")
-def test_pp_create_ok(pp_api_init, op_api_init):
-    module_args = {
-        "name": "protection_policy1",
-        "display_name": "some_display_name",
-        "local_rpo": 43,
-        "local_retention": "2H",
-        "state": "present",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pp_create_ok(pp_api_init, op_api_init, module_args_present):
+    module_args = module_args_present
+    module_args["display_name"] = "some_display_name"
+
     set_module_args(module_args)
 
     pp_mock = MagicMock()

--- a/tests/functional/test_fusion_pp.py
+++ b/tests/functional/test_fusion_pp.py
@@ -1,0 +1,531 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2023 Pure Storage, Inc.
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from unittest.mock import MagicMock, patch
+
+import fusion as purefusion
+import pytest
+from ansible.module_utils import basic
+from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
+    OperationException,
+)
+from ansible_collections.purestorage.fusion.plugins.modules import fusion_pp
+from ansible_collections.purestorage.fusion.tests.functional.utils import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    OperationMock,
+    exit_json,
+    fail_json,
+    set_module_args,
+)
+from urllib3.exceptions import HTTPError
+
+# GLOBAL MOCKS
+fusion_pp.setup_fusion = MagicMock(return_value=purefusion.api_client.ApiClient())
+purefusion.api_client.ApiClient.call_api = MagicMock(
+    side_effect=Exception("API call not mocked!")
+)
+basic.AnsibleModule.exit_json = exit_json
+basic.AnsibleModule.fail_json = fail_json
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+@pytest.mark.parametrize(
+    "module_args",
+    [
+        # 'name` is missing
+        {
+            "local_rpo": 10,
+            "local_retention": "10M",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'local_rpo` is missing
+        {
+            "name": "protection_policy1",
+            "local_retention": "10M",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'local_retention` is missing
+        {
+            "name": "protection_policy1",
+            "local_rpo": 10,
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'local_rpo` is invalid
+        {
+            "name": "protection_policy1",
+            "local_rpo": 10,
+            "local_retention": "10yen",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'local_retention` is invalid
+        {
+            "name": "protection_policy1",
+            "local_rpo": "10bread",
+            "local_retention": "bre",
+            "state": "present",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'state` is invalid
+        {
+            "name": "protection_policy1",
+            "local_rpo": 10,
+            "local_retention": 10,
+            "state": "past",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+    ],
+)
+def test_module_args_wrong(pp_api_init, op_api_init, module_args):
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(side_effect=purefusion.rest.ApiException)
+    pp_mock.create_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_mock.delete_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=purefusion.rest.ApiException)
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleFailJson):
+        fusion_pp.main()
+
+    if pp_mock.get_protection_policy.called:
+        pp_mock.get_protection_policy.assert_called_with(
+            protection_policy_name="protection_policy1"
+        )
+    pp_mock.create_protection_policy.assert_not_called()
+    pp_mock.delete_protection_policy.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+def test_pp_create_ok(pp_api_init, op_api_init):
+    module_args = {
+        "name": "protection_policy1",
+        "display_name": "some_display_name",
+        "local_rpo": 43,
+        "local_retention": "2H",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(side_effect=purefusion.rest.ApiException)
+    pp_mock.create_protection_policy = MagicMock(return_value=OperationMock("op1"))
+    pp_mock.delete_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=True))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pp.main()
+    assert excinfo.value.changed
+
+    pp_mock.get_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    pp_mock.create_protection_policy.assert_called_with(
+        purefusion.ProtectionPolicyPost(
+            name="protection_policy1",
+            display_name="some_display_name",
+            objectives=[
+                purefusion.RPO(type="RPO", rpo="PT43M"),
+                purefusion.Retention(type="Retention", after="PT120M"),
+            ],
+        )
+    )
+    pp_mock.delete_protection_policy.assert_not_called()
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+def test_pp_create_without_display_name_ok(pp_api_init, op_api_init):
+    module_args = {
+        "name": "protection_policy1",
+        "local_rpo": 43,
+        "local_retention": "2H",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(side_effect=purefusion.rest.ApiException)
+    pp_mock.create_protection_policy = MagicMock(return_value=OperationMock("op1"))
+    pp_mock.delete_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=True))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pp.main()
+    assert excinfo.value.changed
+
+    pp_mock.get_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    pp_mock.create_protection_policy.assert_called_with(
+        purefusion.ProtectionPolicyPost(
+            name="protection_policy1",
+            display_name="protection_policy1",
+            objectives=[
+                purefusion.RPO(type="RPO", rpo="PT43M"),
+                purefusion.Retention(type="Retention", after="PT120M"),
+            ],
+        )
+    )
+    pp_mock.delete_protection_policy.assert_not_called()
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+@pytest.mark.parametrize(
+    ("raised_exception", "expected_exception"),
+    [
+        (purefusion.rest.ApiException, purefusion.rest.ApiException),
+        (HTTPError, HTTPError),
+    ],
+)
+def test_pp_create_exception(
+    pp_api_init, op_api_init, raised_exception, expected_exception
+):
+    module_args = {
+        "name": "protection_policy1",
+        "local_rpo": 43,
+        "local_retention": "2H",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(side_effect=purefusion.rest.ApiException)
+    pp_mock.create_protection_policy = MagicMock(side_effect=raised_exception)
+    pp_mock.delete_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(expected_exception):
+        fusion_pp.main()
+
+    pp_mock.get_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    pp_mock.create_protection_policy.assert_called_with(
+        purefusion.ProtectionPolicyPost(
+            name="protection_policy1",
+            display_name="protection_policy1",
+            objectives=[
+                purefusion.RPO(type="RPO", rpo="PT43M"),
+                purefusion.Retention(type="Retention", after="PT120M"),
+            ],
+        )
+    )
+    pp_mock.delete_protection_policy.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+def test_pp_create_op_fails(pp_api_init, op_api_init):
+    module_args = {
+        "name": "protection_policy1",
+        "local_rpo": 43,
+        "local_retention": "2H",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(side_effect=purefusion.rest.ApiException)
+    pp_mock.create_protection_policy = MagicMock(return_value=OperationMock(id="op1"))
+    pp_mock.delete_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=False))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(OperationException):
+        fusion_pp.main()
+
+    pp_mock.get_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    pp_mock.create_protection_policy.assert_called_with(
+        purefusion.ProtectionPolicyPost(
+            name="protection_policy1",
+            display_name="protection_policy1",
+            objectives=[
+                purefusion.RPO(type="RPO", rpo="PT43M"),
+                purefusion.Retention(type="Retention", after="PT120M"),
+            ],
+        )
+    )
+    pp_mock.delete_protection_policy.assert_not_called()
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+def test_pp_delete_ok(pp_api_init, op_api_init):
+    module_args = {
+        "name": "protection_policy1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(
+        return_value=purefusion.ProtectionPolicy(
+            id="protection_policy1_id",
+            name="protection_policy1",
+            display_name="protection_policy1_display_name",
+            self_link="test_self_link",
+            objectives=[
+                purefusion.RPO(type="RPO", rpo="PT43M"),
+                purefusion.Retention(type="Retention", after="PT120M"),
+            ],
+        )
+    )
+    pp_mock.create_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_mock.delete_protection_policy = MagicMock(return_value=OperationMock(id="op1"))
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        return_value=OperationMock(id="op1", success=True)
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pp.main()
+    assert excinfo.value.changed
+
+    pp_mock.get_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    pp_mock.create_protection_policy.assert_not_called()
+    pp_mock.delete_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+@pytest.mark.parametrize(
+    ("raised_exception", "expected_exception"),
+    [
+        (purefusion.rest.ApiException, purefusion.rest.ApiException),
+        (HTTPError, HTTPError),
+    ],
+)
+def test_pp_delete_exception(
+    pp_api_init, op_api_init, raised_exception, expected_exception
+):
+    module_args = {
+        "name": "protection_policy1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(
+        return_value=purefusion.ProtectionPolicy(
+            id="protection_policy1_id",
+            name="protection_policy1",
+            display_name="protection_policy1_display_name",
+            self_link="test_self_link",
+            objectives=[
+                purefusion.RPO(type="RPO", rpo="PT43M"),
+                purefusion.Retention(type="Retention", after="PT120M"),
+            ],
+        )
+    )
+    pp_mock.create_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_mock.delete_protection_policy = MagicMock(side_effect=raised_exception)
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(expected_exception):
+        fusion_pp.main()
+
+    pp_mock.get_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    pp_mock.create_protection_policy.assert_not_called()
+    pp_mock.delete_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+def test_pp_delete_op_fails(pp_api_init, op_api_init):
+    module_args = {
+        "name": "protection_policy1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(
+        return_value=purefusion.ProtectionPolicy(
+            id="protection_policy1_id",
+            name="protection_policy1",
+            display_name="protection_policy1_display_name",
+            self_link="test_self_link",
+            objectives=[
+                purefusion.RPO(type="RPO", rpo="PT43M"),
+                purefusion.Retention(type="Retention", after="PT120M"),
+            ],
+        )
+    )
+    pp_mock.create_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_mock.delete_protection_policy = MagicMock(return_value=OperationMock(id="op1"))
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        return_value=OperationMock(id="op1", success=False)
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(OperationException):
+        fusion_pp.main()
+
+    pp_mock.get_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    pp_mock.create_protection_policy.assert_not_called()
+    pp_mock.delete_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+def test_pp_present_not_changed(pp_api_init, op_api_init):
+    module_args = {
+        "name": "protection_policy1",
+        "display_name": "some_display_name",
+        "local_rpo": 43,
+        "local_retention": "2H",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(
+        return_value=purefusion.ProtectionPolicy(
+            id="protection_policy1_id",
+            name="protection_policy1",
+            display_name="some_display_name",
+            self_link="test_self_link",
+            objectives=[
+                purefusion.RPO(type="RPO", rpo="PT43M"),
+                purefusion.Retention(type="Retention", after="PT120M"),
+            ],
+        )
+    )
+    pp_mock.create_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_mock.delete_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pp.main()
+    assert not excinfo.value.changed
+
+    pp_mock.get_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    pp_mock.create_protection_policy.assert_not_called()
+    pp_mock.delete_protection_policy.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.ProtectionPoliciesApi")
+def test_pp_absent_not_changed(pp_api_init, op_api_init):
+    module_args = {
+        "name": "protection_policy1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    pp_mock = MagicMock()
+    pp_mock.get_protection_policy = MagicMock(side_effect=purefusion.rest.ApiException)
+    pp_mock.create_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_mock.delete_protection_policy = MagicMock(side_effect=NotImplementedError())
+    pp_api_init.return_value = pp_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_pp.main()
+    assert not excinfo.value.changed
+
+    pp_mock.get_protection_policy.assert_called_with(
+        protection_policy_name="protection_policy1"
+    )
+    pp_mock.create_protection_policy.assert_not_called()
+    pp_mock.delete_protection_policy.assert_not_called()
+    op_mock.get_operation.assert_not_called()

--- a/tests/functional/test_fusion_pp.py
+++ b/tests/functional/test_fusion_pp.py
@@ -35,65 +35,105 @@ basic.AnsibleModule.exit_json = exit_json
 basic.AnsibleModule.fail_json = fail_json
 
 
+@pytest.fixture
+def module_args_present():
+    return {
+        "name": "protection_policy1",
+        "local_rpo": 43,
+        "local_retention": "2H",
+        "state": "present",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+
+
+@pytest.fixture
+def module_args_absent():
+    return {
+        "name": "protection_policy1",
+        "state": "absent",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+
+
 @patch("fusion.OperationsApi")
 @patch("fusion.ProtectionPoliciesApi")
 @pytest.mark.parametrize(
-    "module_args",
+    ("module_args", "get_not_called"),
     [
         # 'name` is missing
-        {
-            "local_rpo": 10,
-            "local_retention": "10M",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "local_rpo": 10,
+                "local_retention": "10M",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            True,
+        ),
         # 'local_rpo` is missing
-        {
-            "name": "protection_policy1",
-            "local_retention": "10M",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "protection_policy1",
+                "local_retention": "10M",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            False,
+        ),
         # 'local_retention` is missing
-        {
-            "name": "protection_policy1",
-            "local_rpo": 10,
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "protection_policy1",
+                "local_rpo": 10,
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            False,
+        ),
         # 'local_rpo` is invalid
-        {
-            "name": "protection_policy1",
-            "local_rpo": 10,
-            "local_retention": "10yen",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "protection_policy1",
+                "local_rpo": 10,
+                "local_retention": "10yen",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            False,
+        ),
         # 'local_retention` is invalid
-        {
-            "name": "protection_policy1",
-            "local_rpo": "10bread",
-            "local_retention": "bre",
-            "state": "present",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "protection_policy1",
+                "local_rpo": "10bread",
+                "local_retention": "bre",
+                "state": "present",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            False,
+        ),
         # 'state` is invalid
-        {
-            "name": "protection_policy1",
-            "local_rpo": 10,
-            "local_retention": 10,
-            "state": "past",
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
+        (
+            {
+                "name": "protection_policy1",
+                "local_rpo": 10,
+                "local_retention": 10,
+                "state": "past",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            False,
+        ),
     ],
 )
-def test_module_args_wrong(pp_api_init, op_api_init, module_args):
+def test_module_args_wrong(pp_api_init, op_api_init, module_args, get_not_called):
     set_module_args(module_args)
 
     pp_mock = MagicMock()
@@ -109,6 +149,8 @@ def test_module_args_wrong(pp_api_init, op_api_init, module_args):
     with pytest.raises(AnsibleFailJson):
         fusion_pp.main()
 
+    if get_not_called:
+        pp_mock.get_protection_policy.assert_not_called()
     if pp_mock.get_protection_policy.called:
         pp_mock.get_protection_policy.assert_called_with(
             protection_policy_name="protection_policy1"
@@ -165,15 +207,10 @@ def test_pp_create_ok(pp_api_init, op_api_init):
 
 @patch("fusion.OperationsApi")
 @patch("fusion.ProtectionPoliciesApi")
-def test_pp_create_without_display_name_ok(pp_api_init, op_api_init):
-    module_args = {
-        "name": "protection_policy1",
-        "local_rpo": 43,
-        "local_retention": "2H",
-        "state": "present",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pp_create_without_display_name_ok(
+    pp_api_init, op_api_init, module_args_present
+):
+    module_args = module_args_present
     set_module_args(module_args)
 
     pp_mock = MagicMock()
@@ -217,16 +254,9 @@ def test_pp_create_without_display_name_ok(pp_api_init, op_api_init):
     ],
 )
 def test_pp_create_exception(
-    pp_api_init, op_api_init, raised_exception, expected_exception
+    pp_api_init, op_api_init, raised_exception, expected_exception, module_args_present
 ):
-    module_args = {
-        "name": "protection_policy1",
-        "local_rpo": 43,
-        "local_retention": "2H",
-        "state": "present",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+    module_args = module_args_present
     set_module_args(module_args)
 
     pp_mock = MagicMock()
@@ -261,15 +291,8 @@ def test_pp_create_exception(
 
 @patch("fusion.OperationsApi")
 @patch("fusion.ProtectionPoliciesApi")
-def test_pp_create_op_fails(pp_api_init, op_api_init):
-    module_args = {
-        "name": "protection_policy1",
-        "local_rpo": 43,
-        "local_retention": "2H",
-        "state": "present",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pp_create_op_fails(pp_api_init, op_api_init, module_args_present):
+    module_args = module_args_present
     set_module_args(module_args)
 
     pp_mock = MagicMock()
@@ -304,13 +327,8 @@ def test_pp_create_op_fails(pp_api_init, op_api_init):
 
 @patch("fusion.OperationsApi")
 @patch("fusion.ProtectionPoliciesApi")
-def test_pp_delete_ok(pp_api_init, op_api_init):
-    module_args = {
-        "name": "protection_policy1",
-        "state": "absent",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pp_delete_ok(pp_api_init, op_api_init, module_args_absent):
+    module_args = module_args_absent
     set_module_args(module_args)
 
     pp_mock = MagicMock()
@@ -360,14 +378,9 @@ def test_pp_delete_ok(pp_api_init, op_api_init):
     ],
 )
 def test_pp_delete_exception(
-    pp_api_init, op_api_init, raised_exception, expected_exception
+    pp_api_init, op_api_init, raised_exception, expected_exception, module_args_absent
 ):
-    module_args = {
-        "name": "protection_policy1",
-        "state": "absent",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+    module_args = module_args_absent
     set_module_args(module_args)
 
     pp_mock = MagicMock()
@@ -406,13 +419,8 @@ def test_pp_delete_exception(
 
 @patch("fusion.OperationsApi")
 @patch("fusion.ProtectionPoliciesApi")
-def test_pp_delete_op_fails(pp_api_init, op_api_init):
-    module_args = {
-        "name": "protection_policy1",
-        "state": "absent",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pp_delete_op_fails(pp_api_init, op_api_init, module_args_absent):
+    module_args = module_args_absent
     set_module_args(module_args)
 
     pp_mock = MagicMock()
@@ -500,13 +508,8 @@ def test_pp_present_not_changed(pp_api_init, op_api_init):
 
 @patch("fusion.OperationsApi")
 @patch("fusion.ProtectionPoliciesApi")
-def test_pp_absent_not_changed(pp_api_init, op_api_init):
-    module_args = {
-        "name": "protection_policy1",
-        "state": "absent",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_pp_absent_not_changed(pp_api_init, op_api_init, module_args_absent):
+    module_args = module_args_absent
     set_module_args(module_args)
 
     pp_mock = MagicMock()

--- a/tests/functional/test_fusion_ra.py
+++ b/tests/functional/test_fusion_ra.py
@@ -35,6 +35,30 @@ basic.AnsibleModule.exit_json = exit_json
 basic.AnsibleModule.fail_json = fail_json
 
 
+@pytest.fixture
+def module_args_present():
+    return {
+        "state": "present",
+        "role": "az-admin",
+        "user": "user1",
+        "scope": "organization",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+
+
+@pytest.fixture
+def module_args_absent():
+    return {
+        "state": "absent",
+        "role": "az-admin",
+        "user": "user1",
+        "scope": "organization",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+
+
 @patch("fusion.OperationsApi")
 @patch("fusion.IdentityManagerApi")
 @patch("fusion.RoleAssignmentsApi")
@@ -153,15 +177,10 @@ def test_module_args_wrong(ra_api_init, im_api_init, op_api_init, module_args):
 @patch("fusion.OperationsApi")
 @patch("fusion.IdentityManagerApi")
 @patch("fusion.RoleAssignmentsApi")
-def test_ra_user_does_not_exist(ra_api_init, im_api_init, op_api_init):
-    module_args = {
-        "state": "present",
-        "role": "az-admin",
-        "user": "user1",
-        "scope": "organization",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_ra_user_does_not_exist(
+    ra_api_init, im_api_init, op_api_init, module_args_present
+):
+    module_args = module_args_present
     set_module_args(module_args)
 
     ra_mock = MagicMock()
@@ -286,16 +305,14 @@ def test_ra_create_ok(ra_api_init, im_api_init, op_api_init, args_and_scope):
     ],
 )
 def test_ra_create_exception(
-    ra_api_init, im_api_init, op_api_init, raised_exception, expected_exception
+    ra_api_init,
+    im_api_init,
+    op_api_init,
+    raised_exception,
+    expected_exception,
+    module_args_present,
 ):
-    module_args = {
-        "state": "present",
-        "role": "az-admin",
-        "user": "user1",
-        "scope": "organization",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+    module_args = module_args_present
     set_module_args(module_args)
 
     ra_mock = MagicMock()
@@ -336,15 +353,8 @@ def test_ra_create_exception(
 @patch("fusion.OperationsApi")
 @patch("fusion.IdentityManagerApi")
 @patch("fusion.RoleAssignmentsApi")
-def test_ra_create_op_fails(ra_api_init, im_api_init, op_api_init):
-    module_args = {
-        "state": "present",
-        "role": "az-admin",
-        "user": "user1",
-        "scope": "organization",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_ra_create_op_fails(ra_api_init, im_api_init, op_api_init, module_args_present):
+    module_args = module_args_present
     set_module_args(module_args)
 
     ra_mock = MagicMock()
@@ -510,16 +520,14 @@ def test_ra_delete_ok(ra_api_init, im_api_init, op_api_init, args_and_scope):
     ],
 )
 def test_ra_delete_exception(
-    ra_api_init, im_api_init, op_api_init, raised_exception, expected_exception
+    ra_api_init,
+    im_api_init,
+    op_api_init,
+    raised_exception,
+    expected_exception,
+    module_args_absent,
 ):
-    module_args = {
-        "state": "absent",
-        "role": "az-admin",
-        "user": "user1",
-        "scope": "organization",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+    module_args = module_args_absent
     set_module_args(module_args)
 
     ra_mock = MagicMock()
@@ -579,15 +587,8 @@ def test_ra_delete_exception(
 @patch("fusion.OperationsApi")
 @patch("fusion.IdentityManagerApi")
 @patch("fusion.RoleAssignmentsApi")
-def test_ra_delete_op_fails(ra_api_init, im_api_init, op_api_init):
-    module_args = {
-        "state": "absent",
-        "role": "az-admin",
-        "user": "user1",
-        "scope": "organization",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_ra_delete_op_fails(ra_api_init, im_api_init, op_api_init, module_args_absent):
+    module_args = module_args_absent
     set_module_args(module_args)
 
     ra_mock = MagicMock()
@@ -649,15 +650,10 @@ def test_ra_delete_op_fails(ra_api_init, im_api_init, op_api_init):
 @patch("fusion.OperationsApi")
 @patch("fusion.IdentityManagerApi")
 @patch("fusion.RoleAssignmentsApi")
-def test_ra_present_not_changed(ra_api_init, im_api_init, op_api_init):
-    module_args = {
-        "state": "present",
-        "role": "az-admin",
-        "user": "user1",
-        "scope": "organization",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_ra_present_not_changed(
+    ra_api_init, im_api_init, op_api_init, module_args_present
+):
+    module_args = module_args_present
     set_module_args(module_args)
 
     ra_mock = MagicMock()
@@ -716,15 +712,10 @@ def test_ra_present_not_changed(ra_api_init, im_api_init, op_api_init):
 @patch("fusion.OperationsApi")
 @patch("fusion.IdentityManagerApi")
 @patch("fusion.RoleAssignmentsApi")
-def test_ra_absent_not_changed(ra_api_init, im_api_init, op_api_init):
-    module_args = {
-        "state": "absent",
-        "role": "az-admin",
-        "user": "user1",
-        "scope": "organization",
-        "issuer_id": "ABCD1234",
-        "private_key_file": "private-key.pem",
-    }
+def test_ra_absent_not_changed(
+    ra_api_init, im_api_init, op_api_init, module_args_absent
+):
+    module_args = module_args_absent
     set_module_args(module_args)
 
     ra_mock = MagicMock()

--- a/tests/functional/test_fusion_ra.py
+++ b/tests/functional/test_fusion_ra.py
@@ -1,0 +1,760 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2023 Pure Storage, Inc.
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from unittest.mock import MagicMock, patch
+
+import fusion as purefusion
+import pytest
+from ansible.module_utils import basic
+from ansible_collections.purestorage.fusion.plugins.module_utils.errors import (
+    OperationException,
+)
+from ansible_collections.purestorage.fusion.plugins.modules import fusion_ra
+from ansible_collections.purestorage.fusion.tests.functional.utils import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    OperationMock,
+    exit_json,
+    fail_json,
+    set_module_args,
+)
+from urllib3.exceptions import HTTPError
+
+# GLOBAL MOCKS
+fusion_ra.setup_fusion = MagicMock(return_value=purefusion.api_client.ApiClient())
+purefusion.api_client.ApiClient.call_api = MagicMock(
+    side_effect=Exception("API call not mocked!")
+)
+basic.AnsibleModule.exit_json = exit_json
+basic.AnsibleModule.fail_json = fail_json
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+@pytest.mark.parametrize(
+    "module_args",
+    [
+        # 'role` is missing
+        {
+            "state": "present",
+            "tenant": "tenant1",
+            "tenant_space": "tenant_space1",
+            "user": "user1",
+            "scope": "tenant_space",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'user` is missing
+        {
+            "state": "present",
+            "role": "tenant-space-admin",
+            "tenant": "tenant1",
+            "tenant_space": "tenant_space1",
+            "scope": "tenant_space",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'scope` is invalid
+        {
+            "state": "present",
+            "role": "tenant-space-admin",
+            "tenant": "tenant1",
+            "tenant_space": "tenant_space1",
+            "user": "user1",
+            "scope": "bikini_bottom",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'state` is invalid
+        {
+            "state": "past",
+            "role": "tenant-space-admin",
+            "tenant": "tenant1",
+            "tenant_space": "tenant_space1",
+            "user": "user1",
+            "scope": "tenant_space",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'tenant` is missing #1
+        {
+            "state": "present",
+            "role": "tenant-space-admin",
+            "tenant_space": "tenant_space1",
+            "user": "user1",
+            "scope": "tenant_space",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'tenant` is missing #2
+        {
+            "state": "present",
+            "role": "tenant-space-admin",
+            "tenant_space": "tenant_space1",
+            "user": "user1",
+            "scope": "tenant",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+        # 'tenant_space` is missing
+        {
+            "state": "present",
+            "role": "tenant-space-admin",
+            "tenant": "tenant1",
+            "user": "user1",
+            "scope": "tenant_space",
+            "issuer_id": "ABCD1234",
+            "private_key_file": "private-key.pem",
+        },
+    ],
+)
+def test_module_args_wrong(ra_api_init, im_api_init, op_api_init, module_args):
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(side_effect=NotImplementedError())
+    ra_mock.create_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_mock.delete_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(
+        return_value=[
+            purefusion.User(
+                id="principal1",
+                self_link="test_value",
+                name="user1",
+                email="example@example.com",
+            )
+        ]
+    )
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=purefusion.rest.ApiException)
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleFailJson):
+        fusion_ra.main()
+
+    ra_mock.list_role_assignments.assert_not_called()
+    ra_mock.create_role_assignment.assert_not_called()
+    ra_mock.delete_role_assignment.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+def test_ra_user_does_not_exist(ra_api_init, im_api_init, op_api_init):
+    module_args = {
+        "state": "present",
+        "role": "az-admin",
+        "user": "user1",
+        "scope": "organization",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(side_effect=purefusion.rest.ApiException)
+    ra_mock.create_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_mock.delete_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(return_value=[])
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=purefusion.rest.ApiException)
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleFailJson):
+        fusion_ra.main()
+
+    ra_mock.list_role_assignments.assert_not_called()
+    ra_mock.create_role_assignment.assert_not_called()
+    ra_mock.delete_role_assignment.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+@pytest.mark.parametrize(
+    "args_and_scope",
+    [
+        # organization scope
+        (
+            {
+                "state": "present",
+                "role": "az-admin",
+                "user": "user1",
+                "scope": "organization",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            "/",
+        ),
+        # tenant scope
+        (
+            {
+                "state": "present",
+                "role": "tenant-admin",
+                "user": "user1",
+                "scope": "tenant",
+                "tenant": "tenant1",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            "/tenants/tenant1",
+        ),
+        # tenant space scope
+        (
+            {
+                "state": "present",
+                "role": "tenant-space-admin",
+                "user": "user1",
+                "scope": "tenant_space",
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            "/tenants/tenant1/tenant-spaces/tenant_space1",
+        ),
+    ],
+)
+def test_ra_create_ok(ra_api_init, im_api_init, op_api_init, args_and_scope):
+    module_args = args_and_scope[0]
+    ra_scope = args_and_scope[1]
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(return_value=[])
+    ra_mock.create_role_assignment = MagicMock(return_value=OperationMock("op1"))
+    ra_mock.delete_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(
+        return_value=[
+            purefusion.User(
+                id="principal1",
+                self_link="test_value",
+                name="user1",
+                email="example@example.com",
+            )
+        ]
+    )
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=True))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_ra.main()
+    assert excinfo.value.changed
+
+    ra_mock.list_role_assignments.assert_called_with(role_name=module_args["role"])
+    ra_mock.create_role_assignment.assert_called_with(
+        purefusion.RoleAssignmentPost(scope=ra_scope, principal="principal1"),
+        role_name=module_args["role"],
+    )
+    ra_mock.delete_role_assignment.assert_not_called()
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+@pytest.mark.parametrize(
+    ("raised_exception", "expected_exception"),
+    [
+        (purefusion.rest.ApiException, purefusion.rest.ApiException),
+        (HTTPError, HTTPError),
+    ],
+)
+def test_ra_create_exception(
+    ra_api_init, im_api_init, op_api_init, raised_exception, expected_exception
+):
+    module_args = {
+        "state": "present",
+        "role": "az-admin",
+        "user": "user1",
+        "scope": "organization",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(return_value=[])
+    ra_mock.create_role_assignment = MagicMock(side_effect=raised_exception)
+    ra_mock.delete_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(
+        return_value=[
+            purefusion.User(
+                id="principal1",
+                self_link="test_value",
+                name="user1",
+                email="example@example.com",
+            )
+        ]
+    )
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(expected_exception):
+        fusion_ra.main()
+
+    ra_mock.list_role_assignments.assert_called_with(role_name="az-admin")
+    ra_mock.create_role_assignment.assert_called_with(
+        purefusion.RoleAssignmentPost(scope="/", principal="principal1"),
+        role_name="az-admin",
+    )
+    ra_mock.delete_role_assignment.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+def test_ra_create_op_fails(ra_api_init, im_api_init, op_api_init):
+    module_args = {
+        "state": "present",
+        "role": "az-admin",
+        "user": "user1",
+        "scope": "organization",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(return_value=[])
+    ra_mock.create_role_assignment = MagicMock(return_value=OperationMock(id="op1"))
+    ra_mock.delete_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(
+        return_value=[
+            purefusion.User(
+                id="principal1",
+                self_link="test_value",
+                name="user1",
+                email="example@example.com",
+            )
+        ]
+    )
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(return_value=OperationMock("op1", success=False))
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(OperationException):
+        fusion_ra.main()
+
+    ra_mock.list_role_assignments.assert_called_with(role_name="az-admin")
+    ra_mock.create_role_assignment.assert_called_with(
+        purefusion.RoleAssignmentPost(scope="/", principal="principal1"),
+        role_name="az-admin",
+    )
+    ra_mock.delete_role_assignment.assert_not_called()
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+@pytest.mark.parametrize(
+    "args_and_scope",
+    [
+        # organization scope
+        (
+            {
+                "state": "absent",
+                "role": "az-admin",
+                "user": "user1",
+                "scope": "organization",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            purefusion.ResourceMetadata(
+                id="org_id",
+                name="org",
+                self_link="/",
+            ),
+        ),
+        # tenant scope
+        (
+            {
+                "state": "absent",
+                "role": "tenant-admin",
+                "user": "user1",
+                "scope": "tenant",
+                "tenant": "tenant1",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            purefusion.ResourceMetadata(
+                id="tenant1_id",
+                name="tenant1",
+                self_link="/tenants/tenant1",
+            ),
+        ),
+        # tenant space scope
+        (
+            {
+                "state": "absent",
+                "role": "tenant-space-admin",
+                "user": "user1",
+                "scope": "tenant_space",
+                "tenant": "tenant1",
+                "tenant_space": "tenant_space1",
+                "issuer_id": "ABCD1234",
+                "private_key_file": "private-key.pem",
+            },
+            purefusion.ResourceMetadata(
+                id="tenant_space1_id",
+                name="tenant_space1",
+                self_link="/tenants/tenant1/tenant-spaces/tenant_space1",
+            ),
+        ),
+    ],
+)
+def test_ra_delete_ok(ra_api_init, im_api_init, op_api_init, args_and_scope):
+    module_args = args_and_scope[0]
+    ra_scope = args_and_scope[1]
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(
+        return_value=[
+            purefusion.RoleAssignment(
+                id="ra1_id",
+                name="ra1",
+                self_link="test_value",
+                role=purefusion.RoleRef(
+                    id="role1_id",
+                    name=module_args["role"],
+                    kind="Role",
+                    self_link="test_value",
+                ),
+                scope=ra_scope,
+                principal="principal1",
+            )
+        ]
+    )
+    ra_mock.create_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_mock.delete_role_assignment = MagicMock(return_value=OperationMock(id="op1"))
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(
+        return_value=[
+            purefusion.User(
+                id="principal1",
+                self_link="test_value",
+                name="user1",
+                email="example@example.com",
+            )
+        ]
+    )
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        return_value=OperationMock(id="op1", success=True)
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_ra.main()
+    assert excinfo.value.changed
+
+    ra_mock.list_role_assignments.assert_called_with(role_name=module_args["role"])
+    ra_mock.create_role_assignment.assert_not_called()
+    ra_mock.delete_role_assignment.assert_called_with(
+        role_name=module_args["role"], role_assignment_name="ra1"
+    )
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+@pytest.mark.parametrize(
+    ("raised_exception", "expected_exception"),
+    [
+        (purefusion.rest.ApiException, purefusion.rest.ApiException),
+        (HTTPError, HTTPError),
+    ],
+)
+def test_ra_delete_exception(
+    ra_api_init, im_api_init, op_api_init, raised_exception, expected_exception
+):
+    module_args = {
+        "state": "absent",
+        "role": "az-admin",
+        "user": "user1",
+        "scope": "organization",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(
+        return_value=[
+            purefusion.RoleAssignment(
+                id="ra1_id",
+                name="ra1",
+                self_link="test_value",
+                role=purefusion.RoleRef(
+                    id="role1_id",
+                    name=module_args["role"],
+                    kind="Role",
+                    self_link="test_value",
+                ),
+                scope=purefusion.ResourceMetadata(
+                    id="org_id",
+                    name="org",
+                    self_link="/",
+                ),
+                principal="principal1",
+            )
+        ]
+    )
+    ra_mock.create_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_mock.delete_role_assignment = MagicMock(side_effect=raised_exception)
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(
+        return_value=[
+            purefusion.User(
+                id="principal1",
+                self_link="test_value",
+                name="user1",
+                email="example@example.com",
+            )
+        ]
+    )
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(expected_exception):
+        fusion_ra.main()
+
+    ra_mock.list_role_assignments.assert_called_with(role_name=module_args["role"])
+    ra_mock.create_role_assignment.assert_not_called()
+    ra_mock.delete_role_assignment.assert_called_with(
+        role_name=module_args["role"], role_assignment_name="ra1"
+    )
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+def test_ra_delete_op_fails(ra_api_init, im_api_init, op_api_init):
+    module_args = {
+        "state": "absent",
+        "role": "az-admin",
+        "user": "user1",
+        "scope": "organization",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(
+        return_value=[
+            purefusion.RoleAssignment(
+                id="ra1_id",
+                name="ra1",
+                self_link="test_value",
+                role=purefusion.RoleRef(
+                    id="role1_id",
+                    name=module_args["role"],
+                    kind="Role",
+                    self_link="test_value",
+                ),
+                scope=purefusion.ResourceMetadata(
+                    id="org_id",
+                    name="org",
+                    self_link="/",
+                ),
+                principal="principal1",
+            )
+        ]
+    )
+    ra_mock.create_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_mock.delete_role_assignment = MagicMock(return_value=OperationMock(id="op1"))
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(
+        return_value=[
+            purefusion.User(
+                id="principal1",
+                self_link="test_value",
+                name="user1",
+                email="example@example.com",
+            )
+        ]
+    )
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(
+        return_value=OperationMock(id="op1", success=False)
+    )
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(OperationException):
+        fusion_ra.main()
+
+    ra_mock.list_role_assignments.assert_called_with(role_name=module_args["role"])
+    ra_mock.create_role_assignment.assert_not_called()
+    ra_mock.delete_role_assignment.assert_called_with(
+        role_name=module_args["role"], role_assignment_name="ra1"
+    )
+    op_mock.get_operation.assert_called_with("op1")
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+def test_ra_present_not_changed(ra_api_init, im_api_init, op_api_init):
+    module_args = {
+        "state": "present",
+        "role": "az-admin",
+        "user": "user1",
+        "scope": "organization",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(
+        return_value=[
+            purefusion.RoleAssignment(
+                id="ra1_id",
+                name="ra1",
+                self_link="test_value",
+                role=purefusion.RoleRef(
+                    id="role1_id",
+                    name=module_args["role"],
+                    kind="Role",
+                    self_link="test_value",
+                ),
+                scope=purefusion.ResourceMetadata(
+                    id="org_id",
+                    name="org",
+                    self_link="/",
+                ),
+                principal="principal1",
+            )
+        ]
+    )
+    ra_mock.create_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_mock.delete_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(
+        return_value=[
+            purefusion.User(
+                id="principal1",
+                self_link="test_value",
+                name="user1",
+                email="example@example.com",
+            )
+        ]
+    )
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_ra.main()
+    assert not excinfo.value.changed
+
+    ra_mock.list_role_assignments.assert_called_with(role_name=module_args["role"])
+    ra_mock.create_role_assignment.assert_not_called()
+    ra_mock.delete_role_assignment.assert_not_called()
+    op_mock.get_operation.assert_not_called()
+
+
+@patch("fusion.OperationsApi")
+@patch("fusion.IdentityManagerApi")
+@patch("fusion.RoleAssignmentsApi")
+def test_ra_absent_not_changed(ra_api_init, im_api_init, op_api_init):
+    module_args = {
+        "state": "absent",
+        "role": "az-admin",
+        "user": "user1",
+        "scope": "organization",
+        "issuer_id": "ABCD1234",
+        "private_key_file": "private-key.pem",
+    }
+    set_module_args(module_args)
+
+    ra_mock = MagicMock()
+    ra_mock.list_role_assignments = MagicMock(return_value=[])
+    ra_mock.create_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_mock.delete_role_assignment = MagicMock(side_effect=NotImplementedError())
+    ra_api_init.return_value = ra_mock
+
+    im_mock = MagicMock()
+    im_mock.list_users = MagicMock(
+        return_value=[
+            purefusion.User(
+                id="principal1",
+                self_link="test_value",
+                name="user1",
+                email="example@example.com",
+            )
+        ]
+    )
+    im_api_init.return_value = im_mock
+
+    op_mock = MagicMock()
+    op_mock.get_operation = MagicMock(side_effect=NotImplementedError())
+    op_api_init.return_value = op_mock
+
+    with pytest.raises(AnsibleExitJson) as excinfo:
+        fusion_ra.main()
+    assert not excinfo.value.changed
+
+    ra_mock.list_role_assignments.assert_called_with(role_name=module_args["role"])
+    ra_mock.create_role_assignment.assert_not_called()
+    ra_mock.delete_role_assignment.assert_not_called()
+    op_mock.get_operation.assert_not_called()

--- a/tests/functional/test_fusion_region.py
+++ b/tests/functional/test_fusion_region.py
@@ -125,7 +125,7 @@ def test_region_create(m_region_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_region.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_region.assert_called_once_with(region_name=module_args["name"])
@@ -167,7 +167,7 @@ def test_region_create_without_display_name(m_region_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_region.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_region.assert_called_once_with(region_name=module_args["name"])
@@ -353,7 +353,7 @@ def test_region_update(m_region_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_region.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_region.assert_called_once_with(region_name=module_args["name"])
@@ -561,7 +561,7 @@ def test_region_present_not_changed(m_region_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_region.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_region.assert_called_once_with(region_name=module_args["name"])
@@ -600,7 +600,7 @@ def test_region_absent_not_changed(m_region_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_region.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_region.assert_called_once_with(region_name=module_args["name"])
@@ -645,7 +645,7 @@ def test_region_delete(m_region_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_region.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_region.assert_called_once_with(region_name=module_args["name"])

--- a/tests/functional/test_fusion_sc.py
+++ b/tests/functional/test_fusion_sc.py
@@ -166,7 +166,7 @@ def test_sc_create(
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_sc.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_class.assert_called_once_with(
@@ -223,7 +223,7 @@ def test_sc_create_without_display_name(m_sc_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_sc.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_class.assert_called_once_with(
@@ -607,7 +607,7 @@ def test_sc_update(m_sc_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_sc.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_class.assert_called_once_with(
@@ -871,7 +871,7 @@ def test_sc_present_not_changed(m_sc_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_sc.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_class.assert_called_once_with(
@@ -917,7 +917,7 @@ def test_sc_absent_not_changed(m_sc_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_sc.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_class.assert_called_once_with(
@@ -975,7 +975,7 @@ def test_sc_update_limits_not_changed(m_sc_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_sc.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_class.assert_called_once_with(
@@ -1033,7 +1033,7 @@ def test_sc_delete(m_sc_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_sc.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_class.assert_called_once_with(

--- a/tests/functional/test_fusion_se.py
+++ b/tests/functional/test_fusion_se.py
@@ -237,7 +237,7 @@ def test_se_create(m_se_api, m_op_api, module_args):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_se.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_endpoint.assert_called_once_with(
@@ -288,7 +288,7 @@ def test_se_create_without_display_name(m_se_api, m_op_api, module_args):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_se.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_endpoint.assert_called_once_with(
@@ -503,7 +503,7 @@ def test_se_update(m_se_api, m_op_api, module_args, current_se):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_se.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_endpoint.assert_called_once_with(
@@ -698,7 +698,7 @@ def test_se_present_not_changed(m_se_api, m_op_api, module_args, current_se):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_se.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_endpoint.assert_called_once_with(
@@ -735,7 +735,7 @@ def test_se_absent_not_changed(m_se_api, m_op_api, module_args, current_se):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_se.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_endpoint.assert_called_once_with(
@@ -774,7 +774,7 @@ def test_se_delete(m_se_api, m_op_api, module_args, current_se):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_se.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_endpoint.assert_called_once_with(

--- a/tests/functional/test_fusion_ss.py
+++ b/tests/functional/test_fusion_ss.py
@@ -138,7 +138,7 @@ def test_ss_create(m_ss_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ss.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_service.assert_called_once_with(
@@ -185,7 +185,7 @@ def test_ss_create_without_display_name(m_ss_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ss.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_service.assert_called_once_with(
@@ -433,7 +433,7 @@ def test_ss_update(m_ss_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ss.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_service.assert_called_once_with(
@@ -661,7 +661,7 @@ def test_ss_present_not_changed(m_ss_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ss.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_service.assert_called_once_with(
@@ -702,7 +702,7 @@ def test_ss_absent_not_changed(m_ss_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ss.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_service.assert_called_once_with(
@@ -752,7 +752,7 @@ def test_ss_delete(m_ss_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ss.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_storage_service.assert_called_once_with(

--- a/tests/functional/test_fusion_tenant.py
+++ b/tests/functional/test_fusion_tenant.py
@@ -125,7 +125,7 @@ def test_tenant_create(m_tenant_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_tenant.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant.assert_called_once_with(tenant_name=module_args["name"])
@@ -168,7 +168,7 @@ def test_tenant_create_without_display_name(m_tenant_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_tenant.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant.assert_called_once_with(tenant_name=module_args["name"])
@@ -358,7 +358,7 @@ def test_tenant_update(m_tenant_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_tenant.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant.assert_called_once_with(tenant_name=module_args["name"])
@@ -566,7 +566,7 @@ def test_tenant_present_not_changed(m_tenant_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_tenant.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant.assert_called_once_with(tenant_name=module_args["name"])
@@ -605,7 +605,7 @@ def test_tenant_absent_not_changed(m_tenant_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_tenant.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant.assert_called_once_with(tenant_name=module_args["name"])
@@ -650,7 +650,7 @@ def test_tenant_delete(m_tenant_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_tenant.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant.assert_called_once_with(tenant_name=module_args["name"])

--- a/tests/functional/test_fusion_ts.py
+++ b/tests/functional/test_fusion_ts.py
@@ -137,7 +137,7 @@ def test_ts_create(m_ts_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ts.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant_space.assert_called_once_with(
@@ -185,7 +185,7 @@ def test_ts_create_without_display_name(m_ts_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ts.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant_space.assert_called_once_with(
@@ -398,7 +398,7 @@ def test_ts_update(m_ts_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ts.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant_space.assert_called_once_with(
@@ -638,7 +638,7 @@ def test_ts_present_not_changed(m_ts_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ts.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant_space.assert_called_once_with(
@@ -681,7 +681,7 @@ def test_ts_absent_not_changed(m_ts_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ts.main()
 
-    assert exc.value.args[0]["changed"] is False
+    assert not exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant_space.assert_called_once_with(
@@ -733,7 +733,7 @@ def test_ts_delete(m_ts_api, m_op_api):
     with pytest.raises(AnsibleExitJson) as exc:
         fusion_ts.main()
 
-    assert exc.value.args[0]["changed"] is True
+    assert exc.value.changed
 
     # check api was called correctly
     api_obj.get_tenant_space.assert_called_once_with(

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -96,3 +96,19 @@ def fail_json(*args, **kwargs):
 
     kwargs["failed"] = True
     raise AnsibleFailJson(args, kwargs)
+
+
+def side_effects_with_exceptions(side_effects):
+    """
+    Works similarly to `MagicMock(side_effect=side_effects)` as if side_effects was a list,
+    but if item in the list is instance of an exception, it raises it instead of returning it.
+    """
+    side_effects = side_effects.copy()
+
+    def _exec_side_effect(*args, **kwargs):
+        i = side_effects.pop(0)
+        if isinstance(i, Exception):
+            raise i
+        return i
+
+    return _exec_side_effect

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -15,7 +15,14 @@ class OperationMock:
     Mock Operation object. This object should be returned by mocked api.
     """
 
-    id: int
+    def __init__(self, id=None, success=None):
+        if success is None:
+            self.status = "Pending"
+        elif success:
+            self.status = "Succeeded"
+        else:
+            self.status = "Failed"
+        self.id = id
 
 
 class SuccessfulOperationMock:
@@ -50,7 +57,13 @@ class AnsibleExitJson(Exception):
     Docs: https://docs.ansible.com/ansible/latest/dev_guide/testing_units_modules.html
     """
 
-    pass
+    def __init__(self, args, kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    @property
+    def changed(self):
+        return self.kwargs["changed"]
 
 
 class AnsibleFailJson(Exception):
@@ -59,7 +72,9 @@ class AnsibleFailJson(Exception):
     Docs: https://docs.ansible.com/ansible/latest/dev_guide/testing_units_modules.html
     """
 
-    pass
+    def __init__(self, args, kwargs):
+        self.args = args
+        self.kwargs = kwargs
 
 
 def exit_json(*args, **kwargs):
@@ -70,7 +85,7 @@ def exit_json(*args, **kwargs):
 
     if "changed" not in kwargs:
         kwargs["changed"] = False
-    raise AnsibleExitJson(kwargs)
+    raise AnsibleExitJson(args, kwargs)
 
 
 def fail_json(*args, **kwargs):
@@ -80,4 +95,4 @@ def fail_json(*args, **kwargs):
     """
 
     kwargs["failed"] = True
-    raise AnsibleFailJson(kwargs)
+    raise AnsibleFailJson(args, kwargs)

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -100,15 +100,15 @@ def fail_json(*args, **kwargs):
 
 def side_effects_with_exceptions(side_effects):
     """
-    Works similarly to `MagicMock(side_effect=side_effects)` as if side_effects was a list,
+    Assumes side_effects is a list. Works similarly to `MagicMock(side_effect=side_effects)`,
     but if item in the list is instance of an exception, it raises it instead of returning it.
     """
     side_effects = side_effects.copy()
 
-    def _exec_side_effect(*args, **kwargs):
+    def _pop_side_effect(*args, **kwargs):
         i = side_effects.pop(0)
         if isinstance(i, Exception):
             raise i
         return i
 
-    return _exec_side_effect
+    return _pop_side_effect


### PR DESCRIPTION
##### SUMMARY
Implement functional tests for `fusion_pg.py`, `fusion_pp.py` and `fusion_ra.py`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fusion_ra.py
fusion_pp.py
fusion_pg.py
test_fusion_ra.py
test_fusion_pp.py
test_fusion_pg.py

##### ADDITIONAL INFORMATION
Following issues were found and fixed during implementation:
- fusion_ra.py: Role name was passed in under `name`, which is really confusing because role assignments also have a name field which seems to be equal to their ID. `name` was deprecated and aliased to `role` instead.
- fusion_pp.py: `local_rpo` accepted only numbers even though it actually contains similar time duration as `local_retention`, which accepts ISO 8601-like strings. `local_rpo` was changed to accept the same input as `local_retention`.
- fusion_pg.py: Placement Group, when created, got array selected by placement engine and `array` field was ignored. If the playbook was run second time, the Placement Group was migrated to the array user wanted. Placement Group is now migrated immediately during creation.
- 'utils.py': Refactored helper test exceptions because their working mechanism was awkward.