### PR TITLE
Add support for CBS Storage Endpoint

### DIFF
--- a/changelogs/134_add_cbs_storage_endpoint_support.yml
+++ b/changelogs/134_add_cbs_storage_endpoint_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- fusion_se - add support for CBS Storage Endpoint

--- a/changelogs/134_add_cbs_storage_endpoint_support.yml
+++ b/changelogs/134_add_cbs_storage_endpoint_support.yml
@@ -1,2 +1,5 @@
 minor_changes:
 - fusion_se - add support for CBS Storage Endpoint
+
+deprecated_features:
+- fusion_se - `endpoint_type` parameter is now deprecated and will be removed in version 2.0.0

--- a/plugins/modules/fusion_se.py
+++ b/plugins/modules/fusion_se.py
@@ -49,10 +49,10 @@ options:
     required: true
   endpoint_type:
     description:
-    - Type of the storage endpoint. Only iSCSI is available at the moment.
+    - Type of the storage endpoint.
     type: str
     default: iscsi
-    choices: [ iscsi ]
+    choices: [ iscsi, cbs-azure-iscsi ]
   iscsi:
     description:
     - List of discovery interfaces.
@@ -72,6 +72,24 @@ options:
       network_interface_groups:
         description:
         - List of network interface groups to assign to the address.
+        type: list
+        elements: str
+  cbs_azure_iscsi:
+    description:
+    - CBS Azure iSCSI
+    type: dict
+    suboptions:
+      storage_endpoint_collection_identity:
+        description:
+        - The Storage Endpoint Collection Identity which belongs to the Azure entities.
+        type: str
+      load_balancer:
+        description:
+        - The Load Balancer id which gives permissions to CBS array applications to modify the Load Balancer.
+        type: str
+      load_balancer_addresses:
+        description:
+        - The IPv4 addresses of the Load Balancer.
         type: list
         elements: str
   network_interface_groups:
@@ -119,6 +137,22 @@ EXAMPLES = r"""
     issuer_id: key_name
     private_key_file: "az-admin-private-key.pem"
 
+- name: Create new CBS storage endpoint foo in AZ bar
+  purestorage.fusion.fusion_se:
+    name: foo
+    availability_zone: bar
+    region: us-west
+    endpoint_type: cbs-azure-iscsi
+    cbs_azure_iscsi:
+      storage_endpoint_collection_identity: "/subscriptions/sub/resourcegroups/sec/providers/ms/userAssignedIdentities/secId"
+      load_balancer: "/subscriptions/sub/resourcegroups/sec/providers/ms/loadBalancers/sec-lb"
+      load_balancer_addresses:
+        - 10.21.200.1
+        - 10.21.200.2
+    state: present
+    app_id: key_name
+    key_file: "az-admin-private-key.pem"
+
 - name: Delete storage endpoint foo in AZ bar
   purestorage.fusion.fusion_se:
     name: foo
@@ -159,6 +193,7 @@ from ansible_collections.purestorage.fusion.plugins.module_utils.fusion import (
 
 from ansible_collections.purestorage.fusion.plugins.module_utils.networking import (
     is_valid_network,
+    is_valid_address,
 )
 from ansible_collections.purestorage.fusion.plugins.module_utils.startup import (
     setup_fusion,
@@ -238,20 +273,35 @@ def create_se(module, fusion):
     se_api_instance = purefusion.StorageEndpointsApi(fusion)
 
     if not module.check_mode:
-        discovery_interfaces = [
-            purefusion.StorageEndpointIscsiDiscoveryInterfacePost(**endpoint)
-            for endpoint in module.params["iscsi"]
-        ]
-        storage_endpoint = purefusion.StorageEndpointPost(
-            name=module.params["name"],
-            display_name=module.params["display_name"] or module.params["name"],
-            endpoint_type=module.params["endpoint_type"],
-            iscsi=purefusion.StorageEndpointIscsiPost(
-                discovery_interfaces=discovery_interfaces
-            ),
-        )
+        iscsi = None
+        if module.params["endpoint_type"] == "iscsi":
+            iscsi = purefusion.StorageEndpointIscsiPost(
+                discovery_interfaces=[
+                    purefusion.StorageEndpointIscsiDiscoveryInterfacePost(**endpoint)
+                    for endpoint in module.params["iscsi"]
+                ]
+            )
+
+        cbs_azure_iscsi = None
+        if module.params["endpoint_type"] == "cbs-azure-iscsi":
+            cbs_azure_iscsi = purefusion.StorageEndpointCbsAzureIscsiPost(
+                storage_endpoint_collection_identity=module.params["cbs_azure_iscsi"][
+                    "storage_endpoint_collection_identity"
+                ],
+                load_balancer=module.params["cbs_azure_iscsi"]["load_balancer"],
+                load_balancer_addresses=module.params["cbs_azure_iscsi"][
+                    "load_balancer_addresses"
+                ],
+            )
+
         op = se_api_instance.create_storage_endpoint(
-            storage_endpoint,
+            purefusion.StorageEndpointPost(
+                name=module.params["name"],
+                display_name=module.params["display_name"] or module.params["name"],
+                endpoint_type=module.params["endpoint_type"],
+                iscsi=iscsi,
+                cbs_azure_iscsi=cbs_azure_iscsi,
+            ),
             region_name=module.params["region"],
             availability_zone_name=module.params["availability_zone"],
         )
@@ -311,7 +361,9 @@ def main():
             display_name=dict(type="str"),
             region=dict(type="str", required=True),
             availability_zone=dict(type="str", required=True, aliases=["az"]),
-            endpoint_type=dict(type="str", default="iscsi", choices=["iscsi"]),
+            endpoint_type=dict(
+                type="str", default="iscsi", choices=["iscsi", "cbs-azure-iscsi"]
+            ),
             iscsi=dict(
                 type="list",
                 elements="dict",
@@ -319,6 +371,14 @@ def main():
                     address=dict(type="str"),
                     gateway=dict(type="str"),
                     network_interface_groups=dict(type="list", elements="str"),
+                ),
+            ),
+            cbs_azure_iscsi=dict(
+                type="dict",
+                options=dict(
+                    storage_endpoint_collection_identity=dict(type="str"),
+                    load_balancer=dict(type="str"),
+                    load_balancer_addresses=dict(type="list", elements="str"),
                 ),
             ),
             state=dict(type="str", default="present", choices=["absent", "present"]),
@@ -343,15 +403,23 @@ def main():
         )
     )
 
-    # can not use both deprecated and new fields at the same time
+    required_if = [
+        ("endpoint_type", "iscsi", ("iscsi",)),
+        ("endpoint_type", "cbs-azure-iscsi", ("cbs_azure_iscsi",)),
+    ]
     mutually_exclusive = [
-        ("iscsi", "addresses"),
-        ("iscsi", "gateway"),
-        ("iscsi", "network_interface_groups"),
+        ("iscsi", "cbs_azure_iscsi"),
+        # can not use both deprecated and new fields at the same time
+        ("iscsi", "cbs_azure_iscsi", "addresses"),
+        ("iscsi", "cbs_azure_iscsi", "gateway"),
+        ("iscsi", "cbs_azure_iscsi", "network_interface_groups"),
     ]
 
     module = AnsibleModule(
-        argument_spec, mutually_exclusive=mutually_exclusive, supports_check_mode=True
+        argument_spec,
+        mutually_exclusive=mutually_exclusive,
+        required_if=required_if,
+        supports_check_mode=True,
     )
     fusion = setup_fusion(module)
 
@@ -371,13 +439,17 @@ def main():
                 f"{param_name} is deprecated and will be removed in the version 2.0"
             )
 
+        # only iscsi endpoint type is supported in the deprecated code
+        if module.params["endpoint_type"] != "iscsi":
+            module.fail_json(
+                msg=f"Endpoint type '{module.params['endpoint_type']}' is not supported in combination with deprecated parameters. Please use new parameters."
+            )
+
         if module.params["addresses"]:
             for address in module.params["addresses"]:
                 if not is_valid_network(address):
                     module.fail_json(
-                        msg="'{0}' is not a valid address in CIDR notation".format(
-                            address
-                        )
+                        msg=f"'{address}' is not a valid address in CIDR notation"
                     )
 
         sendp = get_se(module, fusion)
@@ -395,14 +467,23 @@ def main():
             delete_se(module, fusion)
     else:
         # user uses new module interface
-        if module.params["iscsi"]:
+        if module.params["iscsi"] is not None:
             for endpoint in module.params["iscsi"]:
                 address = endpoint["address"]
                 if not is_valid_network(address):
                     module.fail_json(
-                        msg="'{0}' is not a valid address in CIDR notation".format(
-                            address
-                        )
+                        msg=f"'{address}' is not a valid address in CIDR notation"
+                    )
+                gateway = endpoint["gateway"]
+                if not is_valid_address(gateway):
+                    module.fail_json(
+                        msg=f"'{gateway}' is not a valid IPv4 address notation"
+                    )
+        if module.params["cbs_azure_iscsi"] is not None:
+            for address in module.params["cbs_azure_iscsi"]["load_balancer_addresses"]:
+                if not is_valid_address(address):
+                    module.fail_json(
+                        msg=f"'{address}' is not a valid IPv4 address notation"
                     )
 
         sendp = get_se(module, fusion)

--- a/tests/functional/test_fusion_se.py
+++ b/tests/functional/test_fusion_se.py
@@ -45,7 +45,6 @@ def module_args():
         "display_name": "Storage Endpoint 1",
         "region": "region1",
         "availability_zone": "az1",
-        "endpoint_type": "iscsi",
         "iscsi": [
             {
                 "address": "10.21.200.124/24",
@@ -67,7 +66,7 @@ def current_se(module_args):
         "display_name": module_args["display_name"],
         "region": module_args["region"],
         "availability_zone": module_args["availability_zone"],
-        "endpoint_type": module_args["endpoint_type"],
+        "endpoint_type": "iscsi",
         "iscsi": [
             dict(discovery_interface) for discovery_interface in module_args["iscsi"]
         ],
@@ -85,7 +84,6 @@ def current_se(module_args):
             "display_name": "Storage Endpoint 1",
             "region": "region1",
             "availability_zone": "az1",
-            "endpoint_type": "iscsi",
             "iscsi": [
                 {
                     "address": "10.21.200.124/24",
@@ -102,7 +100,6 @@ def current_se(module_args):
             "name": "se1",
             "display_name": "Storage Endpoint 1",
             "availability_zone": "az1",
-            "endpoint_type": "iscsi",
             "iscsi": [
                 {
                     "address": "10.21.200.124/24",
@@ -119,7 +116,6 @@ def current_se(module_args):
             "name": "se1",
             "display_name": "Storage Endpoint 1",
             "region": "region1",
-            "endpoint_type": "iscsi",
             "iscsi": [
                 {
                     "address": "10.21.200.124/24",
@@ -137,7 +133,6 @@ def current_se(module_args):
             "display_name": "Storage Endpoint 1",
             "region": "region1",
             "availability_zone": "az1",
-            "endpoint_type": "iscsi",
             "iscsi": [
                 {
                     "address": "10.21.200.124/24",
@@ -156,25 +151,6 @@ def current_se(module_args):
             "display_name": "Storage Endpoint 1",
             "region": "region1",
             "availability_zone": "az1",
-            "endpoint_type": "iscsi",
-            "iscsi": [
-                {
-                    "address": "10.21.200.124/24",
-                    "gateway": "10.21.200.1",
-                    "network_interface_groups": ["subnet-0", "subnet-1"],
-                }
-            ],
-            "issuer_id": "ABCD1234",
-            "private_key_file": "private-key.pem",
-        },
-        # parameter 'endpoint_type` has incorrect value
-        {
-            "state": "present",
-            "name": "se1",
-            "display_name": "Storage Endpoint 1",
-            "region": "region1",
-            "availability_zone": "az1",
-            "endpoint_type": "hole",
             "iscsi": [
                 {
                     "address": "10.21.200.124/24",
@@ -192,7 +168,6 @@ def current_se(module_args):
             "display_name": "Storage Endpoint 1",
             "region": "region1",
             "availability_zone": "az1",
-            "endpoint_type": "cbs-azure-iscsi",
             "iscsi": [
                 {
                     "address": "10.21.200.124/24",
@@ -215,7 +190,6 @@ def current_se(module_args):
             "display_name": "Storage Endpoint 1",
             "region": "region1",
             "availability_zone": "az1",
-            "endpoint_type": "cbs-azure-iscsi",
             "cbs_azure_iscsi": {
                 "storage_endpoint_collection_identity": "/subscriptions/sub/resourcegroups/sec/providers/ms/userAssignedIdentities/secId",
                 "load_balancer": "/subscriptions/sub/resourcegroups/sec/providers/ms/loadBalancers/sec-lb",
@@ -231,7 +205,6 @@ def current_se(module_args):
             "display_name": "Storage Endpoint 1",
             "region": "region1",
             "availability_zone": "az1",
-            "endpoint_type": "iscsi",
             "iscsi": [
                 {
                     "address": "10.21.200.124/24",
@@ -249,7 +222,6 @@ def current_se(module_args):
             "display_name": "Storage Endpoint 1",
             "region": "region1",
             "availability_zone": "az1",
-            "endpoint_type": "iscsi",
             "iscsi": [
                 {
                     "address": "not an address",
@@ -257,28 +229,6 @@ def current_se(module_args):
                     "network_interface_groups": ["subnet-0", "subnet-1"],
                 }
             ],
-            "app_id": "ABCD1234",
-            "key_file": "private-key.pem",
-        },
-        # parameter 'endpoint_type` is set to `iscsi` but `iscsi` parameter is not defined
-        {
-            "state": "present",
-            "name": "se1",
-            "display_name": "Storage Endpoint 1",
-            "region": "region1",
-            "availability_zone": "az1",
-            "endpoint_type": "iscsi",
-            "app_id": "ABCD1234",
-            "key_file": "private-key.pem",
-        },
-        # parameter 'endpoint_type` is set to `cbs-azure-iscsi` but `cbs_azure_iscsi` parameter is not defined
-        {
-            "state": "present",
-            "name": "se1",
-            "display_name": "Storage Endpoint 1",
-            "region": "region1",
-            "availability_zone": "az1",
-            "endpoint_type": "cbs-azure-iscsi",
             "app_id": "ABCD1234",
             "key_file": "private-key.pem",
         },
@@ -346,7 +296,7 @@ def test_se_create_iscsi(m_se_api, m_op_api, module_args):
         purefusion.StorageEndpointPost(
             name=module_args["name"],
             display_name=module_args["display_name"],
-            endpoint_type=module_args["endpoint_type"],
+            endpoint_type="iscsi",
             iscsi=purefusion.StorageEndpointIscsiPost(
                 discovery_interfaces=[
                     purefusion.StorageEndpointIscsiDiscoveryInterfacePost(**endpoint)
@@ -366,7 +316,6 @@ def test_se_create_iscsi(m_se_api, m_op_api, module_args):
 @patch("fusion.StorageEndpointsApi")
 def test_se_create_cbs_azure_iscsi(m_se_api, m_op_api, module_args):
     del module_args["iscsi"]
-    module_args["endpoint_type"] = "cbs-azure-iscsi"
     module_args["cbs_azure_iscsi"] = {
         "storage_endpoint_collection_identity": "/subscriptions/sub/resourcegroups/sec/providers/ms/userAssignedIdentities/secId",
         "load_balancer": "/subscriptions/sub/resourcegroups/sec/providers/ms/loadBalancers/sec-lb",
@@ -403,7 +352,7 @@ def test_se_create_cbs_azure_iscsi(m_se_api, m_op_api, module_args):
         purefusion.StorageEndpointPost(
             name=module_args["name"],
             display_name=module_args["display_name"],
-            endpoint_type=module_args["endpoint_type"],
+            endpoint_type="cbs-azure-iscsi",
             cbs_azure_iscsi=purefusion.StorageEndpointCbsAzureIscsiPost(
                 storage_endpoint_collection_identity=module_args["cbs_azure_iscsi"][
                     "storage_endpoint_collection_identity"
@@ -457,7 +406,7 @@ def test_se_create_without_display_name(m_se_api, m_op_api, module_args):
         purefusion.StorageEndpointPost(
             name=module_args["name"],
             display_name=module_args["name"],
-            endpoint_type=module_args["endpoint_type"],
+            endpoint_type="iscsi",
             iscsi=purefusion.StorageEndpointIscsiPost(
                 discovery_interfaces=[
                     purefusion.StorageEndpointIscsiDiscoveryInterfacePost(**endpoint)
@@ -514,7 +463,7 @@ def test_se_create_exception(
         purefusion.StorageEndpointPost(
             name=module_args["name"],
             display_name=module_args["display_name"],
-            endpoint_type=module_args["endpoint_type"],
+            endpoint_type="iscsi",
             iscsi=purefusion.StorageEndpointIscsiPost(
                 discovery_interfaces=[
                     purefusion.StorageEndpointIscsiDiscoveryInterfacePost(**endpoint)
@@ -562,7 +511,7 @@ def test_se_create_op_fails(m_se_api, m_op_api, module_args):
         purefusion.StorageEndpointPost(
             name=module_args["name"],
             display_name=module_args["display_name"],
-            endpoint_type=module_args["endpoint_type"],
+            endpoint_type="iscsi",
             iscsi=purefusion.StorageEndpointIscsiPost(
                 discovery_interfaces=[
                     purefusion.StorageEndpointIscsiDiscoveryInterfacePost(**endpoint)
@@ -619,7 +568,7 @@ def test_se_create_op_exception(
         purefusion.StorageEndpointPost(
             name=module_args["name"],
             display_name=module_args["display_name"],
-            endpoint_type=module_args["endpoint_type"],
+            endpoint_type="iscsi",
             iscsi=purefusion.StorageEndpointIscsiPost(
                 discovery_interfaces=[
                     purefusion.StorageEndpointIscsiDiscoveryInterfacePost(**endpoint)


### PR DESCRIPTION
##### SUMMARY
Support CBS Storage Endpoint. Deprecation of `endpoint_type` parameter.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- fusion_se

##### ADDITIONAL INFORMATION
Pure Storage Fusion API support CBS Storage Endpoint. This feature introduces this feature to the Ansbile Collection to maintain parity. `endpoint_type` is deprecated as it is redundant (if user uses iscsi or cbs_iscsi can be found out from which parameter `iscsi` or `cbs_azure_iscsi` they use)
