### PR TITLE
Change return type

### DIFF
--- a/plugins/modules/fusion_info.py
+++ b/plugins/modules/fusion_info.py
@@ -67,7 +67,7 @@ RETURN = r"""
 fusion_info:
   description: Returns the information collected from Fusion
   returned: always
-  type: complex
+  type: dict
 """
 
 try:

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,1 +1,0 @@
-plugins/modules/fusion_info.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,1 +1,0 @@
-plugins/modules/fusion_info.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,1 +1,0 @@
-plugins/modules/fusion_info.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,1 +1,0 @@
-plugins/modules/fusion_info.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,1 +1,0 @@
-plugins/modules/fusion_info.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,1 +1,0 @@
-plugins/modules/fusion_info.py validate-modules:return-syntax-error


### PR DESCRIPTION
##### SUMMARY
Return type of `complex` was causing an issue and also required sanity ignore files.
Changing to `dict` allows the sanity files to be removed freeing up issues with the new version of `ansible-lint`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
fusion_info.py