### PR TITLE
Add missing none fields

### DIFF
--- a/changelogs/142_add_missing_none_fields.yml
+++ b/changelogs/142_add_missing_none_fields.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - fusion_info - `hardware_types` is None if missing in `storage_service`
+  - fusion_info - `network_interface_groups` is None if missing in `iscsi_interfaces` in `storage_endpoint`
+  - fusion_info - `array` is None if missing in `volume`

--- a/plugins/modules/fusion_info.py
+++ b/plugins/modules/fusion_info.py
@@ -812,6 +812,7 @@ def generate_storserv_dict(module, fusion):
     for service in services.items:
         ss_dict[service.name] = {
             "display_name": service.display_name,
+            "hardware_types": None,
         }
         # can be None if we don't have permission to see this
         if service.hardware_types is not None:
@@ -847,6 +848,7 @@ def generate_se_dict(module, fusion):
                         "address": iface.address,
                         "gateway": iface.gateway,
                         "mtu": iface.mtu,
+                        "network_interface_groups": None,
                     }
                     if iface.network_interface_groups is not None:
                         dct["network_interface_groups"] = [
@@ -979,10 +981,9 @@ def generate_volumes_dict(module, fusion):
                     "storage_class": volume.storage_class.name,
                     "serial_number": volume.serial_number,
                     "target": {},
+                    "array": getattr(volume.array, "name", None),
                 }
-                # can be None if we don't have permission to see this
-                if volume.array is not None:
-                    volume_info[vol_name]["array"] = volume.array.name
+
                 volume_info[vol_name]["target"] = {
                     "iscsi": {
                         "addresses": volume.target.iscsi.addresses,

--- a/tests/functional/test_fusion_info.py
+++ b/tests/functional/test_fusion_info.py
@@ -954,7 +954,7 @@ def test_info_gather_subset(
     m_default_api.return_value = api_obj
 
     time.tzset()
-    
+
     set_module_args(
         {
             "gather_subset": gather_subset,
@@ -1621,6 +1621,7 @@ def test_info_gather_subset(
             for ts in RESP_TS.items
             for tenant in RESP_TENANTS.items
         }
+
         assert exc.value.fusion_info["volume_snapshots"] == {
             tenant.name
             + "/"
@@ -1998,6 +1999,7 @@ def test_info_hidden_fields_storage_services(m_ss_api):
         "storage_services": {
             service.name: {
                 "display_name": service.display_name,
+                "hardware_types": None,
             }
             for service in response.items
         },
@@ -2078,6 +2080,7 @@ def test_info_hidden_fields_storage_endpoints(m_ss_api, m_az_api, m_region_api):
                         "address": iface.address,
                         "gateway": iface.gateway,
                         "mtu": iface.mtu,
+                        "network_interface_groups": None,
                     }
                     for iface in endpoint.iscsi.discovery_interfaces
                 ],
@@ -2215,6 +2218,7 @@ def test_info_hidden_fields_volumes(m_ss_api, m_az_api, m_region_api):
                         "wwns": None,
                     },
                 },
+                "array": None,
             }
             for volume in response.items
             for tenant_space in RESP_TS.items

--- a/tests/functional/test_fusion_info.py
+++ b/tests/functional/test_fusion_info.py
@@ -25,6 +25,7 @@ from ansible_collections.purestorage.fusion.tests.helpers import (
     ApiExceptionsMockGenerator,
 )
 from urllib3.exceptions import HTTPError
+import time
 
 # GLOBAL MOCKS
 fusion_info.setup_fusion = MagicMock(return_value=purefusion.api_client.ApiClient())
@@ -952,6 +953,8 @@ def test_info_gather_subset(
     m_im_api.return_value = api_obj
     m_default_api.return_value = api_obj
 
+    time.tzset()
+    
     set_module_args(
         {
             "gather_subset": gather_subset,


### PR DESCRIPTION
##### SUMMARY
Add missing none fields to fusion_info module
Some fields were skipped in dictionaries, now they are presented with None values
Fixed fusion_info tests

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fusion_info

