### PR TITLE
Unify keys in fusion_info

### DIFF
--- a/changelogs/143_unify_keys_in_fusion_info.yml
+++ b/changelogs/143_unify_keys_in_fusion_info.yml
@@ -1,0 +1,15 @@
+minor_changes:
+  - fusion_info - introduce 'regions' subset option
+  - fusion_info - introduce 'availability_zones' subset option
+  - fusion_info - introduce 'host_access_policies' subset option
+  - fusion_info - introduce 'network_interfaces' subset option
+  - fusion_info - rename 'zones' dict to 'availability_zones' for consistency
+  - fusion_info - rename 'hosts' dict to 'host_access_policies' for consistency
+  - fusion_info - rename 'interfaces' dict to 'network_interfaces' for consistency
+  - fusion_info - rename 'placements_groups' in default dict to 'placement_groups' for consistency
+  - fusion_info - rename 'appliances' in default dict to 'arrays' for consistency
+
+deprecated_features:
+  - fusion_info - 'zones' subset is deprecated in favor of 'availability_zones' and will be removed in the version 2.0.0
+  - fusion_info - 'hosts' subset is deprecated in favor of 'host_access_policies' and will be removed in the version 2.0.0
+  - fusion_info - 'interfaces' subset is deprecated in favor of 'network_interfaces' and will be removed in the version 2.0.0

--- a/plugins/modules/fusion_info.py
+++ b/plugins/modules/fusion_info.py
@@ -27,11 +27,10 @@ options:
   gather_subset:
     description:
       - When supplied, this argument will define the information to be collected.
-        Possible values for this include all, minimum, roles, users, placements,
-        arrays, hardware_types, volumes, hosts, storage_classes, protection_policies,
-        placement_groups, interfaces, zones, nigs, storage_endpoints, snapshots,
-        storage_services, tenants, tenant_spaces, network_interface_groups and
-        api_clients.
+        Possible values for this include all, minimum, roles, users, arrays, hardware_types,
+        volumes, host_access_policies, storage_classes, protection_policies, placement_groups,
+        network_interfaces, availability_zones, network_interface_groups, storage_endpoints,
+        snapshots, regions, storage_services, tenants, tenant_spaces, network_interface_groups and api_clients.
     type: list
     elements: str
     required: false
@@ -141,10 +140,10 @@ def generate_default_dict(module, fusion):
     role_assignments_num = None
     tenant_spaces_num = None
     volumes_num = None
-    placements_groups_num = None
+    placement_groups_num = None
     snapshots_num = None
     availability_zones_num = None
-    appliances_num = None
+    arrays_num = None
     network_interfaces_num = None
     network_interface_groups_num = None
     storage_endpoints_num = None
@@ -318,7 +317,7 @@ def generate_default_dict(module, fusion):
 
         try:
             plgrp_api_instance = purefusion.PlacementGroupsApi(fusion)
-            placements_groups_num = sum(
+            placement_groups_num = sum(
                 len(
                     plgrp_api_instance.list_placement_groups(
                         tenant_name=tenant.name,
@@ -384,7 +383,7 @@ def generate_default_dict(module, fusion):
 
         try:
             arrays_api_instance = purefusion.ArraysApi(fusion)
-            appliances_num = sum(
+            arrays_num = sum(
                 len(
                     arrays_api_instance.list_arrays(
                         availability_zone_name=availability_zone.name,
@@ -398,7 +397,7 @@ def generate_default_dict(module, fusion):
             )
         except purefusion.rest.ApiException as exc:
             if exc.status == http.HTTPStatus.FORBIDDEN:
-                warning_api_exception("Appliances")
+                warning_api_exception("Arrays")
             else:
                 # other exceptions will be handled by our exception hook
                 raise exc
@@ -475,7 +474,7 @@ def generate_default_dict(module, fusion):
         warning_argument_none("Network Interfaces", "regions")
         warning_argument_none("Network Interface Groups", "regions")
         warning_argument_none("Storage Endpoints", "regions")
-        warning_argument_none("Appliances", "regions")
+        warning_argument_none("Arrays", "regions")
 
     return {
         "version": version,
@@ -491,17 +490,17 @@ def generate_default_dict(module, fusion):
         "role_assignments": role_assignments_num,
         "tenant_spaces": tenant_spaces_num,
         "volumes": volumes_num,
-        "placements_groups": placements_groups_num,
+        "placement_groups": placement_groups_num,
         "snapshots": snapshots_num,
         "availability_zones": availability_zones_num,
-        "appliances": appliances_num,
+        "arrays": arrays_num,
         "network_interfaces": network_interfaces_num,
         "network_interface_groups": network_interface_groups_num,
         "storage_endpoints": storage_endpoints_num,
     }
 
 
-@_api_permission_denied_handler("interfaces")
+@_api_permission_denied_handler("network_interfaces")
 def generate_nics_dict(module, fusion):
     nics_info = {}
     nic_api_instance = purefusion.NetworkInterfacesApi(fusion)
@@ -543,7 +542,7 @@ def generate_nics_dict(module, fusion):
     return nics_info
 
 
-@_api_permission_denied_handler("hosts")
+@_api_permission_denied_handler("host_access_policies")
 def generate_hap_dict(module, fusion):
     hap_info = {}
     api_instance = purefusion.HostAccessPoliciesApi(fusion)
@@ -672,18 +671,27 @@ def generate_pp_dict(module, fusion):
 
 @_api_permission_denied_handler("tenants")
 def generate_tenant_dict(module, fusion):
-    tenant_info = {}
-    api_instance = purefusion.TenantsApi(fusion)
-    tenants = api_instance.list_tenants()
-    for tenant in tenants.items:
-        name = tenant.name
-        tenant_info[name] = {
+    tenants_api_instance = purefusion.TenantsApi(fusion)
+    return {
+        tenant.name: {
             "display_name": tenant.display_name,
         }
-    return tenant_info
+        for tenant in tenants_api_instance.list_tenants().items
+    }
 
 
-@_api_permission_denied_handler("zones")
+@_api_permission_denied_handler("regions")
+def generate_regions_dict(module, fusion):
+    regions_api_instance = purefusion.RegionsApi(fusion)
+    return {
+        region.name: {
+            "display_name": region.display_name,
+        }
+        for region in regions_api_instance.list_regions().items
+    }
+
+
+@_api_permission_denied_handler("availability_zones")
 def generate_zones_dict(module, fusion):
     zones_info = {}
     az_api_instance = purefusion.AvailabilityZonesApi(fusion)
@@ -1036,6 +1044,10 @@ def main():
         "tenant_spaces",
         "network_interface_groups",
         "api_clients",
+        "availability_zones",
+        "host_access_policies",
+        "network_interfaces",
+        "regions",
     )
     for option in subset:
         if option not in valid_subsets:
@@ -1051,8 +1063,14 @@ def main():
         info["hardware_types"] = generate_hardware_types_dict(module, fusion)
     if "users" in subset or "all" in subset:
         info["users"] = generate_users_dict(module, fusion)
-    if "zones" in subset or "all" in subset:
-        info["zones"] = generate_zones_dict(module, fusion)
+    if "regions" in subset or "all" in subset:
+        info["regions"] = generate_regions_dict(module, fusion)
+    if "availability_zones" in subset or "all" in subset or "zones" in subset:
+        info["availability_zones"] = generate_zones_dict(module, fusion)
+        if "zones" in subset:
+            module.warn(
+                "The 'zones' subset is deprecated and will be removed in the version 2.0.0\nUse 'availability_zones' subset instead."
+            )
     if "roles" in subset or "all" in subset:
         info["roles"] = generate_roles_dict(module, fusion)
         info["role_assignments"] = generate_ras_dict(module, fusion)
@@ -1070,10 +1088,18 @@ def main():
             )
     if "storage_classes" in subset or "all" in subset:
         info["storage_classes"] = generate_sc_dict(module, fusion)
-    if "interfaces" in subset or "all" in subset:
-        info["interfaces"] = generate_nics_dict(module, fusion)
-    if "hosts" in subset or "all" in subset:
-        info["hosts"] = generate_hap_dict(module, fusion)
+    if "network_interfaces" in subset or "all" in subset or "interfaces" in subset:
+        info["network_interfaces"] = generate_nics_dict(module, fusion)
+        if "interfaces" in subset:
+            module.warn(
+                "The 'interfaces' subset is deprecated and will be removed in the version 2.0.0\nUse 'network_interfaces' subset instead."
+            )
+    if "host_access_policies" in subset or "all" in subset or "hosts" in subset:
+        info["host_access_policies"] = generate_hap_dict(module, fusion)
+        if "hosts" in subset:
+            module.warn(
+                "The 'hosts' subset is deprecated and will be removed in the version 2.0.0\nUse 'host_access_policies' subset instead."
+            )
     if "arrays" in subset or "all" in subset:
         info["arrays"] = generate_array_dict(module, fusion)
     if "tenants" in subset or "all" in subset:

--- a/tests/functional/test_fusion_info.py
+++ b/tests/functional/test_fusion_info.py
@@ -43,12 +43,12 @@ VALID_SUBSETS = {
     "arrays",
     "hardware_types",
     "volumes",
-    "hosts",
+    "host_access_policies",
     "storage_classes",
     "protection_policies",
     "placement_groups",
-    "interfaces",
-    "zones",
+    "network_interfaces",
+    "availability_zones",
     "storage_endpoints",
     "snapshots",
     "storage_services",
@@ -56,6 +56,7 @@ VALID_SUBSETS = {
     "tenant_spaces",
     "network_interface_groups",
     "api_clients",
+    "regions",
 }
 
 EXPECTED_KEYS = {
@@ -63,7 +64,7 @@ EXPECTED_KEYS = {
         "default",
         "hardware_types",
         "users",
-        "zones",
+        "availability_zones",
         "roles",
         "role_assignments",
         "storage_services",
@@ -71,8 +72,8 @@ EXPECTED_KEYS = {
         "protection_policies",
         "placement_groups",
         "storage_classes",
-        "interfaces",
-        "hosts",
+        "network_interfaces",
+        "host_access_policies",
         "tenants",
         "tenant_spaces",
         "storage_endpoints",
@@ -81,26 +82,28 @@ EXPECTED_KEYS = {
         "volume_snapshots",
         "snapshots",
         "arrays",
+        "regions",
     },
     "minimum": {"default"},
     "arrays": {"arrays"},
     "hardware_types": {"hardware_types"},
     "users": {"users"},
-    "zones": {"zones"},
+    "availability_zones": {"availability_zones"},
     "roles": {"roles", "role_assignments"},
     "storage_services": {"storage_services"},
     "volumes": {"volumes"},
     "protection_policies": {"protection_policies"},
     "placement_groups": {"placement_groups"},
     "storage_classes": {"storage_classes"},
-    "interfaces": {"interfaces"},
-    "hosts": {"hosts"},
+    "network_interfaces": {"network_interfaces"},
+    "host_access_policies": {"host_access_policies"},
     "tenants": {"tenants"},
     "tenant_spaces": {"tenant_spaces"},
     "storage_endpoints": {"storage_endpoints"},
     "api_clients": {"api_clients"},
     "network_interface_groups": {"network_interface_groups"},
     "snapshots": {"snapshots", "volume_snapshots"},
+    "regions": {"regions"},
 }
 
 RESP_VERSION = purefusion.Version(version=1)
@@ -1012,14 +1015,14 @@ def test_info_gather_subset(
     else:
         api_obj.list_users.assert_not_called()
 
-    if "zones" in gather_subset or "all" in gather_subset:
+    if "availability_zones" in gather_subset or "all" in gather_subset:
         api_obj.list_regions.assert_called_with()
         api_obj.list_availability_zones.assert_has_calls(
             [call(region_name=region.name) for region in RESP_REGIONS.items],
             any_order=True,
         )
-        assert "zones" in exc.value.fusion_info
-        assert exc.value.fusion_info["zones"] == {
+        assert "availability_zones" in exc.value.fusion_info
+        assert exc.value.fusion_info["availability_zones"] == {
             zone.name: {
                 "display_name": zone.display_name,
                 "region": zone.region.name,
@@ -1228,7 +1231,7 @@ def test_info_gather_subset(
     else:
         api_obj.list_storage_classes.assert_not_called()
 
-    if "interfaces" in gather_subset or "all" in gather_subset:
+    if "network_interfaces" in gather_subset or "all" in gather_subset:
         api_obj.list_regions.assert_called_with()
         api_obj.list_availability_zones.assert_has_calls(
             [call(region_name=region.name) for region in RESP_REGIONS.items],
@@ -1258,8 +1261,8 @@ def test_info_gather_subset(
             ],
             any_order=True,
         )
-        assert "interfaces" in exc.value.fusion_info
-        assert exc.value.fusion_info["interfaces"] == {
+        assert "network_interfaces" in exc.value.fusion_info
+        assert exc.value.fusion_info["network_interfaces"] == {
             az.name
             + "/"
             + array.name: {
@@ -1321,10 +1324,10 @@ def test_info_gather_subset(
     else:
         api_obj.list_network_interfaces.assert_not_called()
 
-    if "hosts" in gather_subset or "all" in gather_subset:
+    if "host_access_policies" in gather_subset or "all" in gather_subset:
         api_obj.list_host_access_policies.assert_called_with()
-        assert "hosts" in exc.value.fusion_info
-        assert exc.value.fusion_info["hosts"] == {
+        assert "host_access_policies" in exc.value.fusion_info
+        assert exc.value.fusion_info["host_access_policies"] == {
             host.name: {
                 "personality": host.personality,
                 "display_name": host.display_name,
@@ -1433,8 +1436,8 @@ def test_info_gather_subset(
         api_obj.get_array_space.assert_not_called()
         api_obj.get_array_performance.assert_not_called()
         assert "default" in exc.value.fusion_info
-        assert "appliances" in exc.value.fusion_info["default"]
-        assert exc.value.fusion_info["default"]["appliances"] == len(
+        assert "arrays" in exc.value.fusion_info["default"]
+        assert exc.value.fusion_info["default"]["arrays"] == len(
             RESP_REGIONS.items
         ) * len(RESP_AZ.items) * len(RESP_ARRAYS.items)
     else:
@@ -1781,12 +1784,27 @@ def test_info_gather_subset(
             any_order=True,
         )
         assert "default" in exc.value.fusion_info
-        assert "placements_groups" in exc.value.fusion_info["default"]
-        assert exc.value.fusion_info["default"]["placements_groups"] == len(
+        assert "placement_groups" in exc.value.fusion_info["default"]
+        assert exc.value.fusion_info["default"]["placement_groups"] == len(
             RESP_PG.items
         ) * len(RESP_TENANTS.items) * len(RESP_TS.items)
     else:
         api_obj.list_placement_groups.assert_not_called()
+
+    if "regions" in gather_subset or "all" in gather_subset:
+        api_obj.list_regions.assert_called_with()
+        assert "regions" in exc.value.fusion_info
+        assert exc.value.fusion_info["regions"] == {
+            region.name: {
+                "display_name": region.display_name,
+            }
+            for region in RESP_REGIONS.items
+        }
+    elif "minimum" in gather_subset:
+        api_obj.list_regions.assert_called_with()
+        assert "default" in exc.value.fusion_info
+        assert "regions" in exc.value.fusion_info["default"]
+        assert exc.value.fusion_info["default"]["regions"] == len(RESP_REGIONS.items)
 
 
 @patch("fusion.DefaultApi")
@@ -2355,10 +2373,10 @@ def test_info_permission_denied_minimum(
         "role_assignments": None,
         "tenant_spaces": None,
         "volumes": None,
-        "placements_groups": None,
+        "placement_groups": None,
         "snapshots": None,
         "availability_zones": None,
-        "appliances": None,
+        "arrays": None,
         "network_interfaces": None,
         "network_interface_groups": None,
         "storage_endpoints": None,

--- a/tests/integration/targets/fusion_az/tasks/main.yml
+++ b/tests/integration/targets/fusion_az/tasks/main.yml
@@ -14,11 +14,11 @@
 - name: Collect Availability Zones and verify the zone exists
   environment: "{{ test_env }}"
   purestorage.fusion.fusion_info:
-    gather_subset: zones
+    gather_subset: availability_zones
   register: fusion_info
 - name: Validate the task
   ansible.builtin.assert:
-    that: "'test_az' in fusion_info['fusion_info']['zones']"
+    that: "'test_az' in fusion_info['fusion_info']['availability_zones']"
 
 - name: Delete AZ
   purestorage.fusion.fusion_az:
@@ -36,8 +36,8 @@
 - name: Collect Availability Zones and verify the zone does not exist
   environment: "{{ test_env }}"
   purestorage.fusion.fusion_info:
-    gather_subset: zones
+    gather_subset: availability_zones
   register: fusion_info
 - name: Validate the task
   ansible.builtin.assert:
-    that: "'test_az' not in fusion_info['fusion_info']['zones']"
+    that: "'test_az' not in fusion_info['fusion_info']['availability_zones']"

--- a/tests/integration/targets/fusion_hap/tasks/main.yml
+++ b/tests/integration/targets/fusion_hap/tasks/main.yml
@@ -13,12 +13,12 @@
 
 - name: Collect hosts and check the host exists
   purestorage.fusion.fusion_info:
-    gather_subset: hosts
+    gather_subset: host_access_policies
   register: fusion_info
   environment: "{{ test_env }}"
 - name: Validate the task
   ansible.builtin.assert:
-    that: "'hap_foo' in fusion_info['fusion_info']['hosts']"
+    that: "'hap_foo' in fusion_info['fusion_info']['host_access_policies']"
 
 - name: Delete host access policy
   purestorage.fusion.fusion_hap:
@@ -34,9 +34,9 @@
 
 - name: Collect hosts and check the host does not exist
   purestorage.fusion.fusion_info:
-    gather_subset: hosts
+    gather_subset: host_access_policies
   register: fusion_info
   environment: "{{ test_env }}"
 - name: Validate the task
   ansible.builtin.assert:
-    that: "'hap_foo' not in fusion_info['fusion_info']['hosts']"
+    that: "'hap_foo' not in fusion_info['fusion_info']['host_access_policies']"

--- a/tests/integration/targets/fusion_region/tasks/main.yml
+++ b/tests/integration/targets/fusion_region/tasks/main.yml
@@ -10,6 +10,15 @@
       - result is success
       - result is changed
 
+- name: Collect Regions and verify the region exists
+  environment: "{{ test_env }}"
+  purestorage.fusion.fusion_info:
+    gather_subset: regions
+  register: fusion_info
+- name: Validate the task
+  ansible.builtin.assert:
+    that: "'foo_region' in fusion_info['fusion_info']['regions']"
+
 - name: Update Region display_name
   purestorage.fusion.fusion_region:
     name: "foo_region"
@@ -33,3 +42,12 @@
     that:
       - result is success
       - result is changed
+
+- name: Collect Regions and verify the region does not exist
+  environment: "{{ test_env }}"
+  purestorage.fusion.fusion_info:
+    gather_subset: regions
+  register: fusion_info
+- name: Validate the task
+  ansible.builtin.assert:
+    that: "'foo_region' not in fusion_info['fusion_info']['regions']"


### PR DESCRIPTION
##### SUMMARY
Unify keys in fusion_info to improve the user experience.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- fusion_info

##### ADDITIONAL INFORMATION
minor_changes:
  - fusion_info - introduce 'regions' subset option
  - fusion_info - introduce 'availability_zones' subset option
  - fusion_info - introduce 'host_access_policies' subset option
  - fusion_info - introduce 'network_interfaces' subset option
  - fusion_info - rename 'zones' dict to 'availability_zones' for consistency
  - fusion_info - rename 'hosts' dict to 'host_access_policies' for consistency
  - fusion_info - rename 'interfaces' dict to 'network_interfaces' for consistency
  - fusion_info - rename 'placements_groups' in default dict to 'placement_groups' for consistency
  - fusion_info - rename 'appliances' in default dict to 'arrays' for consistency

deprecated_features:
  - fusion_info - 'zones' subset is deprecated in favor of 'availability_zones' and will be removed in the version 2.0.0
  - fusion_info - 'hosts' subset is deprecated in favor of 'host_access_policies' and will be removed in the version 2.0.0
  - fusion_info - 'interfaces' subset is deprecated in favor of 'network_interfaces' and will be removed in the version 2.0.0
