### PR TITLE
Set LC_TIME in test

### DIFF
--- a/tests/functional/test_fusion_info.py
+++ b/tests/functional/test_fusion_info.py
@@ -847,6 +847,7 @@ RESP_VS = purefusion.VolumeSnapshotList(
 
 
 @patch.dict(os.environ, {"TZ": "UTC"})
+@patch.dict(os.environ, {"LC_TIME": "en_US.utf8"})
 @patch("fusion.DefaultApi")
 @patch("fusion.IdentityManagerApi")
 @patch("fusion.ProtectionPoliciesApi")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the tests we are using timestamps comparisons in the **en_US.utf8** format. Set the LC_TIME env variable to be able run tests on the systems with different locales

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test fusion info



```
