### PR TITLE
Improve role-assignment docs

### DIFF
--- a/plugins/modules/fusion_ra.py
+++ b/plugins/modules/fusion_ra.py
@@ -43,7 +43,7 @@ options:
     type: str
   api_client_key:
     description:
-    - The key of API client to assign the role to.
+    - The issuer ID of the API client to assign the role to.
     type: str
   scope:
     description:
@@ -127,7 +127,7 @@ def get_principal(module, fusion):
 
 
 def user_to_principal(fusion, user_id):
-    """Given a human readable Fusion user, such as a Pure 1 App ID
+    """Given a human-readable Fusion user, such as a Pure 1 App ID
     return the associated principal
     """
     id_api_instance = purefusion.IdentityManagerApi(fusion)
@@ -139,7 +139,7 @@ def user_to_principal(fusion, user_id):
 
 
 def apiclient_to_principal(fusion, api_client_key):
-    """Given an API client key, such as "pure1:apikey:123xXxyYyzYzASDF" (also known as issuer_id),
+    """Given an API client issuer ID, such as "pure1:apikey:123xXxyYyzYzASDF",
     return the associated principal
     """
     id_api_instance = purefusion.IdentityManagerApi(fusion)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We sometimes use `api client issuer ID` and `api client key` interchangeably but we should always refer to it as issuer ID for clarity.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`fusion_ra`
