### PR TITLE
Fix protection policy local retention validation

### DIFF
--- a/changelogs/fragments/159_fix_protection_policy_local_retention_validation.yaml
+++ b/changelogs/fragments/159_fix_protection_policy_local_retention_validation.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- fusion_pp - Change the minimum value of the protection policy local retention from 1 to 10

--- a/plugins/modules/fusion_pp.py
+++ b/plugins/modules/fusion_pp.py
@@ -52,7 +52,7 @@ options:
   local_retention:
     description:
     - Retention Duration for periodic snapshots.
-    - Minimum value is 1 minute.
+    - Minimum value is 10 minutes.
     - Value can be provided as m(inutes), h(ours),
       d(ays), w(eeks), or y(ears).
     - If no unit is provided, minutes are assumed.
@@ -124,8 +124,8 @@ def create_pp(module, fusion):
     pp_api_instance = purefusion.ProtectionPoliciesApi(fusion)
     local_rpo = parse_minutes(module, module.params["local_rpo"])
     local_retention = parse_minutes(module, module.params["local_retention"])
-    if local_retention < 1:
-        module.fail_json(msg="Local Retention must be a minimum of 1 minutes")
+    if local_retention < 10:
+        module.fail_json(msg="Local Retention must be a minimum of 10 minutes")
     if local_rpo < 10:
         module.fail_json(msg="Local RPO must be a minimum of 10 minutes")
     changed = True


### PR DESCRIPTION
##### SUMMARY
This PR introduces a fix for the minimum value of the protection policy local retention (the correct minimum value is 10, not 1)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
`fusion_pp`
